### PR TITLE
Numa awareness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dto-test*
+libdto.so*

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ all: libdto dto-test-wodto
 DML_LIB_CXX=-D_GNU_SOURCE
 
 libdto: dto.c
-	gcc -shared -fPIC -Wl,-soname,libdto.so dto.c $(DML_LIB_CXX) -DDTO_STATS_SUPPORT -o libdto.so.1.0 -laccel-config -ldl
+	gcc -shared -fPIC -Wl,-soname,libdto.so dto.c $(DML_LIB_CXX) -DDTO_STATS_SUPPORT -o libdto.so.1.0 -laccel-config -ldl -lnuma
 
 libdto_nostats: dto.c
-	gcc -shared -fPIC -Wl,-soname,libdto.so dto.c $(DML_LIB_CXX) -o libdto.so.1.0 -laccel-config -ldl
+	gcc -shared -fPIC -Wl,-soname,libdto.so dto.c $(DML_LIB_CXX) -o libdto.so.1.0 -laccel-config -ldl -lnuma
 
 install:
 	cp libdto.so.1.0 /usr/lib64/

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ DTO library falls back to using standard APIs on CPU under following scenarios:
 To improve throughput for synchronous offload, DTO uses "pseudo asynchronous" execution using following steps.
 1) After intercepting the API call, DTO splits the API job into two parts; 1) CPU job and 2) DSA job. For example, a 64 KB memcpy may
    be split into 20 KB CPU job and 44 KB DSA job. The split fraction can be configured using an environment variable DTO_CPU_SIZE_FRACTION. 
-2) DTO submits the DSA portion of the job to DSA.
+2) DTO submits the DSA portion of the job to DSA. 
+   If DTO_IS_NUMA_AWARE=1 DTO uses works queues of DSA device located on the same numa node as 
+   buffer (memcpy/memmove - dest buffer, memcmp - ptr2) delivered to method. This reduces UPI traffic.
 3) In parallel, DTO performs the CPU portion of the job using std library on CPU.
 4) DTO waits for DSA to complete (if it hasn't completed already). The wait method can be configured using an environment variable DTO_WAIT_METHOD.
 
@@ -44,6 +46,7 @@ Following environment variables control the behavior of DTO library:
 	DTO_MIN_BYTES=xxxx (specifies minimum size of API call needed for DSA operation execution, default is 8192 bytes)
 	DTO_CPU_SIZE_FRACTION=0.xx (specifies fraction of job performed by CPU, in parallel to DSA). Default is 0.00
 	DTO_AUTO_ADJUST_KNOBS=0/1 (disables/enables auto tuning of cpu_size_fraction and dsa_min_bytes parameters. 0 -- disable, 1 -- enable (default))
+   DTO_IS_NUMA_AWARE=0/1 (disables/enables numa awareness. 0 -- disable (default), 1 -- enable)
 	DTO_WQ_LIST="semi-colon(;) separated list of DSA WQs to use". The WQ names should match their names in /dev/dsa/ directory (see example below).
 				If not specified, DTO will try to auto-discover and use all available WQs.
 	DTO_LOG_FILE=<dto log file path> Redirect the DTO output to the specified file instead of std output (useful for debugging and statistics collection). file name is suffixed by process pid.
@@ -89,6 +92,7 @@ make dto-test-wodto
             export DTO_CPU_SIZE_FRACTION=0.33
             export DTO_AUTO_ADJUST_KNOBS=1
             export DTO_WQ_LIST="wq0.0;wq2.0;wq4.0;wq6.0"
+            export DTO_IS_NUMA_AWARE=1
 	iii. Run the application - (CacheBench example below)
     3b. Using LD_PRELOAD method (doesn not require recompiling the application)
 	i. setup LD_PRELOAD environment variable to point to DTO library

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ To improve throughput for synchronous offload, DTO uses "pseudo asynchronous" ex
 1) After intercepting the API call, DTO splits the API job into two parts; 1) CPU job and 2) DSA job. For example, a 64 KB memcpy may
    be split into 20 KB CPU job and 44 KB DSA job. The split fraction can be configured using an environment variable DTO_CPU_SIZE_FRACTION. 
 2) DTO submits the DSA portion of the job to DSA. 
-   If DTO_IS_NUMA_AWARE=1 DTO uses works queues of DSA device located on the same numa node as 
-   buffer (memcpy/memmove - dest buffer, memcmp - ptr2) delivered to method. This reduces UPI traffic.
+   If DTO_IS_NUMA_AWARE=1 DTO uses work queues of DSA device located on the same numa node as 
+   buffer (memcpy/memmove - dest buffer, memcmp - ptr2) delivered to method. This reduces cross-socket traffic.
 3) In parallel, DTO performs the CPU portion of the job using std library on CPU.
 4) DTO waits for DSA to complete (if it hasn't completed already). The wait method can be configured using an environment variable DTO_WAIT_METHOD.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ To improve throughput for synchronous offload, DTO uses "pseudo asynchronous" ex
    be split into 20 KB CPU job and 44 KB DSA job. The split fraction can be configured using an environment variable DTO_CPU_SIZE_FRACTION. 
 2) DTO submits the DSA portion of the job to DSA. 
    If DTO_IS_NUMA_AWARE=1 DTO uses work queues of DSA device located on the same numa node as 
-   buffer (memcpy/memmove - dest buffer, memcmp - ptr2) delivered to method. This reduces cross-socket traffic.
+   buffer (memcpy/memmove - dest buffer, memcmp - ptr2) delivered to method - buffer centric numa awareness.
+   If DTO_IS_NUMA_AWARE=2 DTO uses work queues of DSA device located on the same numa node as 
+   calling thread cpu - cpu centric numa awareness.
 3) In parallel, DTO performs the CPU portion of the job using std library on CPU.
 4) DTO waits for DSA to complete (if it hasn't completed already). The wait method can be configured using an environment variable DTO_WAIT_METHOD.
 
@@ -46,7 +48,7 @@ Following environment variables control the behavior of DTO library:
 	DTO_MIN_BYTES=xxxx (specifies minimum size of API call needed for DSA operation execution, default is 8192 bytes)
 	DTO_CPU_SIZE_FRACTION=0.xx (specifies fraction of job performed by CPU, in parallel to DSA). Default is 0.00
 	DTO_AUTO_ADJUST_KNOBS=0/1 (disables/enables auto tuning of cpu_size_fraction and dsa_min_bytes parameters. 0 -- disable, 1 -- enable (default))
-   DTO_IS_NUMA_AWARE=0/1 (disables/enables numa awareness. 0 -- disable (default), 1 -- enable)
+   DTO_IS_NUMA_AWARE=0/1/2 (disables/buffer centric/cpu centric numa awareness. 0 -- disable (default), 1 -- buffer centric, 2 - cpu centric)
 	DTO_WQ_LIST="semi-colon(;) separated list of DSA WQs to use". The WQ names should match their names in /dev/dsa/ directory (see example below).
 				If not specified, DTO will try to auto-discover and use all available WQs.
 	DTO_LOG_FILE=<dto log file path> Redirect the DTO output to the specified file instead of std output (useful for debugging and statistics collection). file name is suffixed by process pid.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ To improve throughput for synchronous offload, DTO uses "pseudo asynchronous" ex
    be split into 20 KB CPU job and 44 KB DSA job. The split fraction can be configured using an environment variable DTO_CPU_SIZE_FRACTION. 
 2) DTO submits the DSA portion of the job to DSA. 
    If DTO_IS_NUMA_AWARE=1 DTO uses work queues of DSA device located on the same numa node as 
-   buffer (memcpy/memmove - dest buffer, memcmp - ptr2) delivered to method - buffer centric numa awareness.
+   buffer (memcpy/memmove - dest buffer, memcmp - ptr2) delivered to method - buffer-centric numa awareness.
    If DTO_IS_NUMA_AWARE=2 DTO uses work queues of DSA device located on the same numa node as 
-   calling thread cpu - cpu centric numa awareness.
+   calling thread cpu - cpu-centric numa awareness.
 3) In parallel, DTO performs the CPU portion of the job using std library on CPU.
 4) DTO waits for DSA to complete (if it hasn't completed already). The wait method can be configured using an environment variable DTO_WAIT_METHOD.
 
@@ -48,7 +48,7 @@ Following environment variables control the behavior of DTO library:
 	DTO_MIN_BYTES=xxxx (specifies minimum size of API call needed for DSA operation execution, default is 8192 bytes)
 	DTO_CPU_SIZE_FRACTION=0.xx (specifies fraction of job performed by CPU, in parallel to DSA). Default is 0.00
 	DTO_AUTO_ADJUST_KNOBS=0/1 (disables/enables auto tuning of cpu_size_fraction and dsa_min_bytes parameters. 0 -- disable, 1 -- enable (default))
-   DTO_IS_NUMA_AWARE=0/1/2 (disables/buffer centric/cpu centric numa awareness. 0 -- disable (default), 1 -- buffer centric, 2 - cpu centric)
+   DTO_IS_NUMA_AWARE=0/1/2 (disables/buffer-centric/cpu-centric numa awareness. 0 -- disable (default), 1 -- buffer-centric, 2 - cpu-centric)
 	DTO_WQ_LIST="semi-colon(;) separated list of DSA WQs to use". The WQ names should match their names in /dev/dsa/ directory (see example below).
 				If not specified, DTO will try to auto-discover and use all available WQs.
 	DTO_LOG_FILE=<dto log file path> Redirect the DTO output to the specified file instead of std output (useful for debugging and statistics collection). file name is suffixed by process pid.

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Pre-requisite packages:
 
 Should use glibc version 2.36 or later for best DTO performance. You can use "ldd --version" command to check glibc version on your system. glibc versions less than 2.36 have a bug which reduces DTO performance.
 
-On Fedora/CentOS/Rhel: kernel-headers, accel-config-devel, libuuid-devel
+On Fedora/CentOS/Rhel: kernel-headers, accel-config-devel, libuuid-devel, libnuma-devel
 
-On Ubuntu/Debian: linux-libc-dev, libaccel-config-dev, uuid-dev
+On Ubuntu/Debian: linux-libc-dev, libaccel-config-dev, uuid-dev, libnuma-dev
 
 ```bash
 make libdto

--- a/dto.c
+++ b/dto.c
@@ -752,10 +752,14 @@ static int dsa_init_from_wq_list(char *wq_list)
 
 		dto_get_param_string(dir_fd, "mode", wq_mode);
 
-		if (strcmp(wq_mode, "dedicated") == 0) {
+        if (wq_mode[0] == '\0') {
 			close(dir_fd);
 			rc = -ENOTSUP;
-			goto fail_wq;
+			goto fail_wq;			
+		}
+
+		if (strcmp(wq_mode, "shared") != 0) {
+			continue;
 		}
 
 		wqs[num_wqs].wq_size = dto_get_param_ullong(dir_fd, "size", &rc);

--- a/dto.c
+++ b/dto.c
@@ -1249,7 +1249,7 @@ static void cleanup_dto(void)
 #endif
 	if (log_fd != -1)
 		close(log_fd);
-	
+
 	cleanup_devices();
 }
 
@@ -1264,17 +1264,17 @@ static __always_inline  struct dto_wq *get_wq(void* buf)
 		const int numa_node = get_numa_node(buf);
 		if (numa_node >= 0 && numa_node < MAX_NUMA_NODES) {
 			struct dto_device* dev = devices[numa_node];
-			if (dev != NULL && 
+			if (dev != NULL &&
 				dev->num_wqs > 0) {
 				wq = dev->wqs[dev->next_wq++ % dev->num_wqs];
-			}			
+			}
 		}
 	}
 
 	if (wq == NULL) {
 		wq = &wqs[next_wq++ % num_wqs];
 	}
-	
+
 	return wq;
 }
 

--- a/dto.c
+++ b/dto.c
@@ -1220,7 +1220,7 @@ static int init_dto(void)
 
 			// display configuration
 			LOG_TRACE("log_level: %d, collect_stats: %d, use_std_lib_calls: %d, dsa_min_size: %lu, "
-				"cpu_size_fraction: %.2f, wait_method: %s, auto_adjust_knobs: %d, is_numa_aware: %s\n",
+				"cpu_size_fraction: %.2f, wait_method: %s, auto_adjust_knobs: %d, numa_awareness: %s\n",
 				log_level, collect_stats, use_std_lib_calls, dsa_min_size,
 				cpu_size_fraction, wait_names[wait_method], auto_adjust_knobs, numa_aware_names[is_numa_aware]);
 			for (int i = 0; i < num_wqs; i++)

--- a/dto.c
+++ b/dto.c
@@ -693,9 +693,9 @@ static void correct_devices_list() {
 	ex. SNC4: 8 numa nodes, 2 DSA devices:
 	dsa0 device has numa_node = 0, dsa2 device has numa_node = 4
 	Then we should use dsa0 device for numa_nodes = 0,1,2,3 and dsa2 device for numa_nodes = 4,5,6,7
-	and model the same in devices list.	
- */	
- 	struct dto_device* dev = NULL;
+	and model the same in devices list.
+ */
+	struct dto_device* dev = NULL;
 	for (uint8_t i = 0; i < MAX_NUMA_NODES; i++) {
 		if (devices[i] != NULL) {
 			dev = devices[i];
@@ -707,7 +707,7 @@ static void correct_devices_list() {
 
 static __always_inline  int get_numa_node(void* buf) {
 	int numa_node = -1;
-	
+
 	switch (is_numa_aware) {
         case NA_BUFFER_CENTRIC: {
 			if (buf != NULL) {
@@ -715,7 +715,7 @@ static __always_inline  int get_numa_node(void* buf) {
 
 				// get numa node of memory pointed by buf
 				if (move_pages(0, 1, &buf, NULL, status, 0) == 0) {
-					numa_node = status[0];	
+					numa_node = status[0];
 				} else {
 					LOG_ERROR("move_pages call error: %d - %s", errno, strerror(errno));
 				}
@@ -756,7 +756,7 @@ static void cleanup_devices() {
 		devices[i] = NULL;
 	}
 }
- 
+
 static int dsa_init_from_wq_list(char *wq_list)
 {
 	char *wq;
@@ -820,7 +820,7 @@ static int dsa_init_from_wq_list(char *wq_list)
         if (wq_mode[0] == '\0') {
 			close(dir_fd);
 			rc = -ENOTSUP;
-			goto fail_wq;			
+			goto fail_wq;
 		}
 
 		if (strcmp(wq_mode, "shared") != 0) {
@@ -856,7 +856,7 @@ static int dsa_init_from_wq_list(char *wq_list)
 
 		if (is_numa_aware) {
 			struct dto_device* dev = get_dto_device(dev_numa_node);
-			if (dev != NULL && 
+			if (dev != NULL &&
 				dev->num_wqs < MAX_WQS) {
 				dev->wqs[dev->num_wqs++] = &wqs[num_wqs];
 			}
@@ -911,9 +911,9 @@ static int dsa_init_from_accfg(void)
 	num_wqs = 0;
 
 	accfg_device_foreach(dto_ctx, device) {
-		enum accfg_device_state dstate;		
+		enum accfg_device_state dstate;
 
-    	/* use dsa devices only*/
+		/* use dsa devices only*/
 		if (strncmp(accfg_device_get_devname(device), "dsa", 3)!= 0)
 			continue;
 
@@ -934,7 +934,7 @@ static int dsa_init_from_accfg(void)
 		if (is_numa_aware) {
 			const int dev_numa_node = accfg_device_get_numa_node(device);
 			dev = get_dto_device(dev_numa_node);
-		}	
+		}
 
 		accfg_wq_foreach(device, wq) {
 			enum accfg_wq_state wstate;

--- a/dto.c
+++ b/dto.c
@@ -688,13 +688,6 @@ static struct dto_device* get_dto_device(int dev_numa_node) {
 }
 
 static void correct_devices_list() {
-/* 	Fill NULL gaps in devices list.
-	For SNC configurations there are less DSA devices then numa nodes
-	ex. SNC4: 8 numa nodes, 2 DSA devices:
-	dsa0 device has numa_node = 0, dsa2 device has numa_node = 4
-	Then we should use dsa0 device for numa_nodes = 0,1,2,3 and dsa2 device for numa_nodes = 4,5,6,7
-	and model the same in devices list.
- */
 	struct dto_device* dev = NULL;
 	for (uint8_t i = 0; i < MAX_NUMA_NODES; i++) {
 		if (devices[i] != NULL) {

--- a/dto.c
+++ b/dto.c
@@ -724,6 +724,8 @@ static __always_inline  int get_numa_node(void* buf) {
 				// if (get_mempolicy(&numa_node, NULL, 0, (void *)buf, MPOL_F_NODE | MPOL_F_ADDR) != 0) {
 				// 	LOG_ERROR("get_mempolicy call error: %d - %s", errno, strerror(errno));
 				// }
+			} else {
+				LOG_ERROR("NULL buffer delivered. Unable to detect numa node");
 			}
 		}
 		break;
@@ -1255,8 +1257,7 @@ static __always_inline  struct dto_wq *get_wq(void* buf)
 {
 	struct dto_wq* wq = NULL;
 
-	if (is_numa_aware &&
-		buf != NULL) {
+	if (is_numa_aware) {
 		int status[1] = {-1};
 
 		// get the numa node for the target DSA device

--- a/dto.c
+++ b/dto.c
@@ -1259,7 +1259,7 @@ static __always_inline  struct dto_wq *get_wq(void* buf)
 		buf != NULL) {
 		int status[1] = {-1};
 
-		// get numa node of memory pointed by buf
+		// get the numa node for the target DSA device
 		const int numa_node = get_numa_node(buf);
 		if (numa_node >= 0 && numa_node < MAX_NUMA_NODES) {
 			struct dto_device* dev = devices[numa_node];

--- a/dto.c
+++ b/dto.c
@@ -92,8 +92,8 @@ enum numa_aware {
 
 static const char * const numa_aware_names[] = {
 	[NA_NONE] = "none",
-	[NA_BUFFER_CENTRIC] = "buffer centric",
-	[NA_CPU_CENTRIC] = "cpu centric",
+	[NA_BUFFER_CENTRIC] = "buffer-centric",
+	[NA_CPU_CENTRIC] = "cpu-centric"
 };
 
 // global workqueue variables

--- a/dto.c
+++ b/dto.c
@@ -83,6 +83,19 @@ enum wait_options {
 	WAIT_YIELD
 };
 
+enum numa_aware {
+	NA_NONE = 0,
+	NA_BUFFER_CENTRIC,
+	NA_CPU_CENTRIC,
+	NA_LAST_ENTRY
+};
+
+static const char * const numa_aware_names[] = {
+	[NA_NONE] = "none",
+	[NA_BUFFER_CENTRIC] = "buffer centric",
+	[NA_CPU_CENTRIC] = "cpu centric",
+};
+
 // global workqueue variables
 static struct dto_wq wqs[MAX_WQS];
 static struct dto_device* devices[MAX_NUMA_NODES];
@@ -91,7 +104,7 @@ static atomic_uchar next_wq;
 static atomic_uchar dto_initialized;
 static atomic_uchar dto_initializing;
 static uint8_t use_std_lib_calls;
-static uint8_t is_numa_aware;
+static enum numa_aware is_numa_aware;
 static size_t dsa_min_size = DTO_DEFAULT_MIN_SIZE;
 static int wait_method = WAIT_YIELD;
 static double cpu_size_fraction;
@@ -692,6 +705,45 @@ static void correct_devices_list() {
 	}
 }
 
+static __always_inline  int get_numa_node(void* buf) {
+	int numa_node = -1;
+	
+	switch (is_numa_aware) {
+        case NA_BUFFER_CENTRIC: {
+			if (buf != NULL) {
+				int status[1] = {-1};
+
+				// get numa node of memory pointed by buf
+				if (move_pages(0, 1, &buf, NULL, status, 0) == 0) {
+					numa_node = status[0];	
+				} else {
+					LOG_ERROR("move_pages call error: %d - %s", errno, strerror(errno));
+				}
+
+				// alternatively get_mempolicy can be used
+				// if (get_mempolicy(&numa_node, NULL, 0, (void *)buf, MPOL_F_NODE | MPOL_F_ADDR) != 0) {
+				// 	LOG_ERROR("get_mempolicy call error: %d - %s", errno, strerror(errno));
+				// }
+			}
+		}
+		break;
+		case NA_CPU_CENTRIC: {
+			const int cpu = sched_getcpu();
+			if (cpu != -1) {
+				numa_node = numa_node_of_cpu(sched_getcpu());
+			}
+			else {
+				LOG_ERROR("sched_getcpu call error: %d - %s", errno, strerror(errno));
+			}
+		}
+		break;
+        default:
+		break;
+        }
+
+        return numa_node;
+}
+
 static void cleanup_devices() {
 	struct dto_device* dev = NULL;
 	for (uint i = 0; i < MAX_NUMA_NODES; i++) {
@@ -1074,15 +1126,15 @@ static int init_dto(void)
 			use_std_lib_calls = !!use_std_lib_calls;
 		}
 
-		env_str = getenv("DTO_IS_NUMA_AWARE");
-		if (env_str != NULL) {
-			errno = 0;
-			is_numa_aware = strtoul(env_str, NULL, 10);
-			if (errno)
-				is_numa_aware = 0;
-
-			is_numa_aware = !!is_numa_aware &&
-							numa_available() != -1;
+		if (numa_available() != -1) {
+			env_str = getenv("DTO_IS_NUMA_AWARE");
+			if (env_str != NULL) {
+				errno = 0;
+				is_numa_aware = strtoul(env_str, NULL, 10);
+				if (errno || is_numa_aware >= NA_LAST_ENTRY) {
+					is_numa_aware = NA_NONE;
+				}
+			}
 		}
 
 #ifdef DTO_STATS_SUPPORT
@@ -1168,9 +1220,9 @@ static int init_dto(void)
 
 			// display configuration
 			LOG_TRACE("log_level: %d, collect_stats: %d, use_std_lib_calls: %d, dsa_min_size: %lu, "
-				"cpu_size_fraction: %.2f, wait_method: %s, auto_adjust_knobs: %d, is_numa_aware: %d\n",
+				"cpu_size_fraction: %.2f, wait_method: %s, auto_adjust_knobs: %d, is_numa_aware: %s\n",
 				log_level, collect_stats, use_std_lib_calls, dsa_min_size,
-				cpu_size_fraction, wait_names[wait_method], auto_adjust_knobs, is_numa_aware);
+				cpu_size_fraction, wait_names[wait_method], auto_adjust_knobs, numa_aware_names[is_numa_aware]);
 			for (int i = 0; i < num_wqs; i++)
 				LOG_TRACE("[%d] wq_path: %s, wq_size: %d, dsa_cap: %lx\n", i,
 					wqs[i].wq_path, wqs[i].wq_size, wqs[i].dsa_gencap);
@@ -1208,15 +1260,13 @@ static __always_inline  struct dto_wq *get_wq(void* buf)
 		int status[1] = {-1};
 
 		// get numa node of memory pointed by buf
-		if (move_pages(0, 1, &buf, NULL, status, 0) == 0) {
-			int buf_numa_node = status[0];
-			if (buf_numa_node < MAX_NUMA_NODES) {
-				struct dto_device* dev = devices[buf_numa_node];
-				if (dev != NULL && 
-					dev->num_wqs > 0) {
-					wq = dev->wqs[dev->next_wq++ % dev->num_wqs];
-				}			
-			}
+		const int numa_node = get_numa_node(buf);
+		if (numa_node >= 0 && numa_node < MAX_NUMA_NODES) {
+			struct dto_device* dev = devices[numa_node];
+			if (dev != NULL && 
+				dev->num_wqs > 0) {
+				wq = dev->wqs[dev->next_wq++ % dev->num_wqs];
+			}			
 		}
 	}
 


### PR DESCRIPTION
Added numa awareness support to reduce UPI traffic.
By default numa aweareness is OFF. To enable it use:
`export DTO_IS_NUMA_AWARE=1`

Performance change:
![image](https://github.com/intel/DTO/assets/100339001/60f38771-a590-4e75-8714-4cb4c65e7ccd)

![image](https://github.com/intel/DTO/assets/100339001/831b4aaa-0da3-41eb-93c6-ed0be9ebdfcd)

![image](https://github.com/intel/DTO/assets/100339001/6824bee8-1fc1-4ecf-893a-53af87593b81)

![image](https://github.com/intel/DTO/assets/100339001/72e060c2-5128-43ca-a35a-287bc95db51e)

![image](https://github.com/intel/DTO/assets/100339001/e2f8ea34-9e3f-45f7-9f19-b545af97a4d6)

![image](https://github.com/intel/DTO/assets/100339001/c3995daf-57d3-4f1a-8f4f-ebe05f41a011)

mamcmp - no differences observed

