### PR TITLE
Updated to memmove support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Following environment variables control the behavior of DTO library:
    DTO_DSA_MEMSET=0/1, 1 (default) - DTO uses DSA to process memset, 0 - DTO use system memset
    DTO_DSA_MEMCMP=0/1, 1 (default) - DTO uses DSA to process memcmp, 0 - DTO use system memcmp
    DTO_DSA_CC=0/1, 1 (default) - DTO sets DSA Cache Control flag to 1 if DSA supports cache control, 0 - DTO sets DSA Cache Control flag to 0
+   DTO_OVERLAPPING_MEMMOVE_ACTION=0/1 0 (default) DTO submits memmove operations with overlapping buffers entirely to CPU, 1 - entirely to DSA
    DTO_UMWAIT_DELAY=xxxx defines delay for umwait command (check max possible value at: /sys/devices/system/cpu/umwait_control/max_time), default is 100000
 	DTO_LOG_FILE=<dto log file path> Redirect the DTO output to the specified file instead of std output (useful for debugging and statistics collection). file name is suffixed by process pid.
 	DTO_LOG_LEVEL=0/1/2 controls the log level. higher value means more verbose logging (default 0).

--- a/dto.c
+++ b/dto.c
@@ -1560,7 +1560,6 @@ static bool dto_memcpymove(void *dest, const void *src, size_t n, bool is_memcpy
 		size_t current_cpu_size_fraction = cpu_size_fraction;  // the cpu_size_fraction might be changed by the auto tune algorithm 
 		if (is_overlapping) {
 			threshold = wq->max_transfer_size;
-			cpu_size = 0;
 		} else {
 			threshold = wq->max_transfer_size * 100 / (100 - current_cpu_size_fraction);
 		}

--- a/dto.c
+++ b/dto.c
@@ -217,7 +217,7 @@ static struct timespec dto_start_time;
 			clock_gettime(CLOCK_BOOTTIME, &et);			\
 			t = (((et.tv_sec*1000000000) + et.tv_nsec) -		\
 				((st.tv_sec*1000000000) + st.tv_nsec));		\
-			update_stats(op, orig_n, 0, n, t, STDC_CALL, 0);		\
+			update_stats(op, orig_n, false, n, t, STDC_CALL, 0);		\
 		}								\
 	} while (0)								\
 
@@ -537,12 +537,13 @@ static __always_inline int dsa_execute(struct dto_wq *wq,
 }
 
 #ifdef DTO_STATS_SUPPORT
-static void update_stats(int op, size_t n, uint8_t overlapping, size_t bytes_completed,
+static void update_stats(int op, size_t n, bool overlapping, size_t bytes_completed,
 		uint64_t elapsed_ns, int group, int error_code)
 {
 	// dto_memcpymove didn't actually submit the request to DSA, so there is nothing to log. This will be captured by a second call
-	if(op==MEMMOVE && overlapping && dto_overlapping_memmove_action==OVERLAPPING_CPU && group==DSA_CALL_SUCCESS)
+	if (op == MEMMOVE && overlapping && dto_overlapping_memmove_action == OVERLAPPING_CPU && group == DSA_CALL_SUCCESS) {
 		return;
+	}
 
 	int bucket = (n / HIST_BUCKET_SIZE);
 
@@ -1501,11 +1502,32 @@ static bool is_overlapping_buffers (void *dest, const void *src, size_t n)
 	return true;
 }
 
-static uint8_t dto_memcpymove(void *dest, const void *src, size_t n, bool is_memcpy, int *result)
+static bool dto_memcpymove(void *dest, const void *src, size_t n, bool is_memcpy, int *result)
 {
-	struct dto_wq *wq = get_wq(dest);
+	struct dto_wq *wq;
 	size_t cpu_size, dsa_size;
-	uint8_t is_overlapping = 0;
+	bool is_overlapping;
+
+	thr_bytes_completed = 0;
+
+	if (!is_memcpy && is_overlapping_buffers(dest, src, n)) {
+		cpu_size = 0;
+		is_overlapping = true;
+	} else {
+		/* cpu_size_fraction guaranteed to be >= 0 and < 1 */
+		cpu_size = n * cpu_size_fraction / 100;
+		is_overlapping = false;
+	}
+
+	// If this is an overlapping memmove and the action is to perform on CPU, return having done nothing and
+	// memmove will perform the copy and correctly attribute statistics to stdlib call group
+	if (is_overlapping && dto_overlapping_memmove_action == OVERLAPPING_CPU) {
+		*result = SUCCESS;
+		return true;
+	}
+
+	dsa_size = n - cpu_size;
+	wq = get_wq(dest);
 
 	thr_desc.opcode = DSA_OPCODE_MEMMOVE;
 	thr_desc.flags = IDXD_OP_FLAG_CRAV | IDXD_OP_FLAG_RCR;
@@ -1513,28 +1535,48 @@ static uint8_t dto_memcpymove(void *dest, const void *src, size_t n, bool is_mem
 		thr_desc.flags |= IDXD_OP_FLAG_CC;
 	thr_desc.completion_addr = (uint64_t)&thr_comp;
 
-	/* cpu_size_fraction guaranteed to be >= 0 and < 1 */
-	if (!is_memcpy && is_overlapping_buffers(dest, src, n)) {
-		cpu_size = 0;
-		is_overlapping = 1;
+	if (dsa_size <= wq->max_transfer_size) {
+		thr_desc.src_addr = (uint64_t) src + cpu_size;
+		thr_desc.dst_addr = (uint64_t) dest + cpu_size;
+		thr_desc.xfer_size = (uint32_t) dsa_size;
+		thr_comp.status = 0;
+		if (is_overlapping) {
+			*result = dsa_execute(wq, &thr_desc, &thr_comp.status);
+		} else {
+			*result = dsa_submit(wq, &thr_desc);
+			if (*result == SUCCESS) {
+				if (cpu_size) {
+					if (is_memcpy)
+						orig_memcpy(dest, src, cpu_size);
+					else
+						orig_memmove(dest, src, cpu_size);
+					thr_bytes_completed += cpu_size;
+				}
+				*result = dsa_wait(wq, &thr_desc, &thr_comp.status);
+			}
+		}
 	} else {
-		cpu_size = n * cpu_size_fraction / 100;
-	}
+		uint32_t threshold;
+		size_t current_cpu_size_fraction = cpu_size_fraction;  // the cpu_size_fraction might be changed by the auto tune algorithm 
+		if (is_overlapping) {
+			threshold = wq->max_transfer_size;
+			cpu_size = 0;
+		} else {
+			threshold = wq->max_transfer_size * 100 / (100 - current_cpu_size_fraction);
+		}
 
-	dsa_size = n - cpu_size;
+		do {
+			size_t len;
 
-	thr_bytes_completed = 0;
+			len = n <= threshold ? n : threshold;
 
-	// If this is an overlapping memmove and the action is to perform on CPU, return having done nothing and
-	// memmove will perform the copy and correctly attribute statistics to stdlib call group
-	if (is_overlapping && dto_overlapping_memmove_action == OVERLAPPING_CPU) {
-		thr_bytes_completed = 0;
-		*result = SUCCESS;
-	} else {
+			if (!is_overlapping)
+				cpu_size = len * current_cpu_size_fraction / 100;
 
-		if (dsa_size <= wq->max_transfer_size) {
-			thr_desc.src_addr = (uint64_t) src + cpu_size;
-			thr_desc.dst_addr = (uint64_t) dest + cpu_size;
+			dsa_size = len - cpu_size;
+
+			thr_desc.src_addr = (uint64_t) src + cpu_size + thr_bytes_completed;
+			thr_desc.dst_addr = (uint64_t) dest + cpu_size + thr_bytes_completed;
 			thr_desc.xfer_size = (uint32_t) dsa_size;
 			thr_comp.status = 0;
 			if (is_overlapping){
@@ -1543,67 +1585,27 @@ static uint8_t dto_memcpymove(void *dest, const void *src, size_t n, bool is_mem
 				*result = dsa_submit(wq, &thr_desc);
 				if (*result == SUCCESS) {
 					if (cpu_size) {
+						const void *src1 = src + thr_bytes_completed;
+						void *dest1 = dest + thr_bytes_completed;
+
 						if (is_memcpy)
-							orig_memcpy(dest, src, cpu_size);
+							orig_memcpy(dest1, src1, cpu_size);
 						else
-							orig_memmove(dest, src, cpu_size);
+							orig_memmove(dest1, src1, cpu_size);
 						thr_bytes_completed += cpu_size;
 					}
 					*result = dsa_wait(wq, &thr_desc, &thr_comp.status);
 				}
 			}
-		} else {
-			uint32_t threshold;
-			size_t current_cpu_size_fraction = cpu_size_fraction;  // the cpu_size_fraction might be changed by the auto tune algorithm 
-			if (is_overlapping) {
-				threshold = wq->max_transfer_size;
-				cpu_size = 0;
-			} else {
-				threshold = wq->max_transfer_size * 100 / (100 - current_cpu_size_fraction);
-			}
 
-			do {
-				size_t len;
-
-				len = n <= threshold ? n : threshold;
-
-				if (!is_overlapping)
-					cpu_size = len * current_cpu_size_fraction / 100;
-
-				dsa_size = len - cpu_size;
-
-				thr_desc.src_addr = (uint64_t) src + cpu_size + thr_bytes_completed;
-				thr_desc.dst_addr = (uint64_t) dest + cpu_size + thr_bytes_completed;
-				thr_desc.xfer_size = (uint32_t) dsa_size;
-				thr_comp.status = 0;
-				if (is_overlapping){
-					*result = dsa_execute(wq, &thr_desc, &thr_comp.status);
-				} else {
-					*result = dsa_submit(wq, &thr_desc);
-					if (*result == SUCCESS) {
-						if (cpu_size) {
-							const void *src1 = src + thr_bytes_completed;
-							void *dest1 = dest + thr_bytes_completed;
-
-							if (is_memcpy)
-								orig_memcpy(dest1, src1, cpu_size);
-							else
-								orig_memmove(dest1, src1, cpu_size);
-							thr_bytes_completed += cpu_size;
-						}
-						*result = dsa_wait(wq, &thr_desc, &thr_comp.status);
-					}
-				}
-
-				if (*result != SUCCESS)
-					break;
-				n -= len;
-				/* If remaining bytes are less than dsa_min_size,
-				* dont submit to DSA. Instead, complete remaining
-				* bytes on CPU
-				*/
-			} while (n >= dsa_min_size);
-		}
+			if (*result != SUCCESS)
+				break;
+			n -= len;
+			/* If remaining bytes are less than dsa_min_size,
+			* dont submit to DSA. Instead, complete remaining
+			* bytes on CPU
+			*/
+		} while (n >= dsa_min_size);
 	}
 
 	return is_overlapping;
@@ -1736,7 +1738,7 @@ void *memset(void *s1, int c, size_t n)
 		dto_memset(s1, c, n, &result);
 
 #ifdef DTO_STATS_SUPPORT
-		DTO_COLLECT_STATS_DSA_END(collect_stats, st, et, MEMSET, n, 0, thr_bytes_completed, result);
+		DTO_COLLECT_STATS_DSA_END(collect_stats, st, et, MEMSET, n, false, thr_bytes_completed, result);
 #endif
 		if (thr_bytes_completed != n) {
 			/* fallback to std call if job is only partially completed */
@@ -1786,7 +1788,7 @@ void *memcpy(void *dest, const void *src, size_t n)
 		dto_memcpymove(dest, src, n, 1, &result);
 
 #ifdef DTO_STATS_SUPPORT
-		DTO_COLLECT_STATS_DSA_END(collect_stats, st, et, MEMCOPY, n, 0, thr_bytes_completed, result);
+		DTO_COLLECT_STATS_DSA_END(collect_stats, st, et, MEMCOPY, n, false, thr_bytes_completed, result);
 #endif
 		if (thr_bytes_completed != n) {
 			/* fallback to std call if job is only partially completed */
@@ -1818,7 +1820,7 @@ void *memmove(void *dest, const void *src, size_t n)
 	int result = 0;
 	void *ret = dest;
 	int use_orig_func = USE_ORIG_FUNC(n, dto_dsa_memmove);
-	uint8_t is_overlapping;
+	bool is_overlapping;
 #ifdef DTO_STATS_SUPPORT
 	struct timespec st, et;
 	size_t orig_n = n;
@@ -1893,7 +1895,7 @@ int memcmp(const void *s1, const void *s2, size_t n)
 		ret = dto_memcmp(s1, s2, n, &result);
 
 #ifdef DTO_STATS_SUPPORT
-		DTO_COLLECT_STATS_DSA_END(collect_stats, st, et, MEMCMP, n, 0, thr_bytes_completed, result);
+		DTO_COLLECT_STATS_DSA_END(collect_stats, st, et, MEMCMP, n, false, thr_bytes_completed, result);
 #endif
 		if (thr_bytes_completed != n) {
 			/* fallback to std call if job is only partially completed */


### PR DESCRIPTION
Modified support for memmove to allow user to select whether operations with overlapping buffers are performed entirely on CPU or on DSA

Modified support for memmove to disregard memmove operations with overlapping buffers because they are not split between CPU and DSA Modified dsa_execute function to not call dsa_wait_and_adjust since it is called when the operation wasn't split and the autotune algorithm should not be used.