### PR TITLE
Add CMake build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dto-test*
 libdto.so*
+build*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,78 @@
+cmake_minimum_required(VERSION 3.5...3.31)
+project(DTO VERSION 1.0 LANGUAGES C)
+
+# Default to RelWithDebInfo when no build type is specified.
+# (Skip for multi-config generators, which ignore CMAKE_BUILD_TYPE.)
+get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT _is_multi_config AND NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
+        "Choose the type of build" FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+        Debug Release RelWithDebInfo MinSizeRel)
+    message(STATUS "No build type specified, defaulting to RelWithDebInfo")
+endif()
+
+include(GNUInstallDirs)
+set(CMAKE_INSTALL_LIBDIR lib)
+
+# Build the shared library
+add_library(dto SHARED dto.c)
+add_library(DTO::dto ALIAS dto)
+target_include_directories(dto
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+# set gnu source everywhere
+add_compile_definitions(_GNU_SOURCE)
+
+# Add the -DDTO_STATS_SUPPORT preprocessor definition
+target_compile_definitions(dto PRIVATE DTO_STATS_SUPPORT)
+
+# Link libraries. Use PRIVATE so accel-config/numa/dl are the shared library's
+# own dependencies (resolved via its DT_NEEDED) rather than INTERFACE
+# requirements that would be forced onto every downstream consumer of DTO::dto.
+target_link_libraries(dto PRIVATE dl accel-config numa)
+
+include(CheckCCompilerFlag)
+check_c_compiler_flag("-mwaitpkg" HAS_WAITPKG)
+if (HAS_WAITPKG)
+  target_compile_options(dto PRIVATE -mwaitpkg -march=native)
+endif()
+
+# Build dto-test and dto-test-wodto
+add_executable(dto-test dto-test.c)
+target_link_libraries(dto-test PRIVATE DTO::dto pthread)
+
+add_executable(dto-test-wodto dto-test.c)
+target_link_libraries(dto-test-wodto PRIVATE pthread)
+
+# Install and export the library
+install(TARGETS dto
+        EXPORT DTOTargets
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(FILES dto.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(EXPORT DTOTargets
+        FILE DTOTargets.cmake
+        NAMESPACE DTO::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/DTO)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/DTOConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/DTOConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/DTOConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/DTO)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/DTOConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/DTOConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/DTO)

--- a/DTOConfig.cmake.in
+++ b/DTOConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/DTOTargets.cmake")
+
+check_required_components(DTO)

--- a/README.md
+++ b/README.md
@@ -103,12 +103,27 @@ On Fedora/CentOS/Rhel: kernel-headers, accel-config-devel, libuuid-devel, libnum
 
 On Ubuntu/Debian: linux-libc-dev, libaccel-config-dev, uuid-dev, libnuma-dev
 
+### CMake ###
 ```bash
-make libdto
-make install
+cmake -B build
+cmake --build build -j
+sudo cmake --install build
 ```
 
-Building the test application.
+The CMake build also produces the test applications in the build directory:
+`dto-test` (for the -ldto method) and `dto-test-wodto` (for the LD_PRELOAD method).
+
+CMake installs the library to `/usr/local/lib` by default, while the deprecated
+Makefile installs to `/usr/lib64`. Pass `-DCMAKE_INSTALL_PREFIX=<prefix>` at
+configure time to change the install location.
+
+### Makefile (deprecated) ###
+```bash
+make libdto
+sudo make install
+```
+
+Building the test application with the Makefile:
 ```bash
 # When using -ldto method
 make dto-test


### PR DESCRIPTION
**Stack 1/3** — foundational CMake build.

Introduces a CMake build alongside the existing Makefile:

- builds the shared `libdto` library, with install/export config so downstream projects can `find_package(DTO)`
- builds the `dto-test` / `dto-test-wodto` executables
- adds `DTOConfig.cmake.in` and ignores `build*/`

At this stage accel-config and numa are still hard dependencies (matching the current Makefile); making them optional and adding the test suite come in the follow-up PRs in this stack.

### Stack
1. **Add CMake build system** ← this PR
2. Add optional libnuma / accel-config support — #31
3. Add CTest functional and performance tests — #32
