### PR TITLE
Add CTest functional and performance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dto-test*
 libdto.so*
 build*/
+tests/baselines*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,124 @@ target_link_libraries(dto-test PRIVATE DTO::dto pthread)
 add_executable(dto-test-wodto dto-test.c)
 target_link_libraries(dto-test-wodto PRIVATE pthread)
 
+# ---- Test Suite ----
+option(DTO_BUILD_TESTS "Build the DTO test suite" ON)
+
+if(DTO_BUILD_TESTS)
+    enable_testing()
+
+    # Functional correctness tests (safe to run in CI without DSA hardware)
+    add_executable(dto-test-functional tests/test_functional.c)
+    target_link_libraries(dto-test-functional PRIVATE DTO::dto pthread)
+
+    add_test(NAME functional COMMAND dto-test-functional)
+    set_tests_properties(functional PROPERTIES
+        LABELS "functional"
+        TIMEOUT 120
+    )
+
+    # ---- A/B performance regression test ----
+    # The baseline object is compiled from unguarded upstream sources that
+    # always reference accel-config and numa, so the perf test can only be
+    # built when both features are enabled. The functional test above links
+    # DTO::dto and follows the options, so it is always available.
+    if(DTO_ACCEL_CONFIG_SUPPORT AND DTO_NUMA_SUPPORT)
+        # Compile flags shared by the current and baseline perf objects so the
+        # A/B comparison uses an identical configuration. -mwaitpkg is gated on
+        # compiler support, matching the main library above.
+        set(PERF_OBJ_CFLAGS -O3 -DNDEBUG -march=native -fPIC
+            -D_GNU_SOURCE -DDTO_STATS_SUPPORT
+            -DDTO_ACCEL_CONFIG_SUPPORT -DDTO_NUMA_SUPPORT)
+        if(HAS_WAITPKG)
+            list(APPEND PERF_OBJ_CFLAGS -mwaitpkg)
+        endif()
+
+        # Build current dto.c as object file with renamed symbols (cur_memcpy, etc.)
+        set(PERF_BASELINE_DIR "${CMAKE_BINARY_DIR}/perf_baseline")
+
+        add_custom_command(
+            OUTPUT ${CMAKE_BINARY_DIR}/dto_current.o
+            COMMAND ${CMAKE_C_COMPILER} -c ${PERF_OBJ_CFLAGS}
+                    ${CMAKE_SOURCE_DIR}/dto.c
+                    -o ${CMAKE_BINARY_DIR}/dto_current_raw.o
+            COMMAND objcopy --redefine-sym memcpy=cur_memcpy
+                            --redefine-sym memset=cur_memset
+                            --redefine-sym memcmp=cur_memcmp
+                            --redefine-sym memmove=cur_memmove
+                            ${CMAKE_BINARY_DIR}/dto_current_raw.o
+                            ${CMAKE_BINARY_DIR}/dto_current.o
+            DEPENDS ${CMAKE_SOURCE_DIR}/dto.c
+            COMMENT "Building dto_current.o with renamed symbols"
+        )
+
+        # Build baseline dto.o from baseline branch (cached by SHA). The same
+        # PERF_OBJ_CFLAGS are forwarded so the baseline matches the current object.
+        # A custom target (not a custom command) so the script runs on every
+        # build: its SHA check against upstream decides whether the cached
+        # object is still fresh, and a custom command would never re-run once
+        # the object exists.
+        add_custom_target(dto_baseline_build
+            COMMAND bash ${CMAKE_SOURCE_DIR}/tests/build_baseline.sh
+                    ${CMAKE_SOURCE_DIR} ${PERF_BASELINE_DIR} ${CMAKE_C_COMPILER}
+                    ${PERF_OBJ_CFLAGS}
+            BYPRODUCTS ${PERF_BASELINE_DIR}/dto_baseline.o
+            COMMENT "Building dto_baseline.o from baseline branch"
+        )
+
+        add_executable(dto-test-perf
+            tests/test_perf.c
+            ${CMAKE_BINARY_DIR}/dto_current.o
+            ${PERF_BASELINE_DIR}/dto_baseline.o
+        )
+        add_dependencies(dto-test-perf dto_baseline_build)
+        target_link_libraries(dto-test-perf PRIVATE m dl pthread accel-config numa)
+
+        # Common env vars for perf tests
+        # Pin core and uncore frequency to 2000 MHz by default; override with
+        # -DPERF_CORE_FREQ_MHZ=... and/or -DPERF_UNCORE_FREQ_MHZ=...
+        if(NOT DEFINED PERF_CORE_FREQ_MHZ)
+            set(PERF_CORE_FREQ_MHZ 2000)
+        endif()
+        if(NOT DEFINED PERF_UNCORE_FREQ_MHZ)
+            set(PERF_UNCORE_FREQ_MHZ 2000)
+        endif()
+
+        set(PERF_COMMON_ENV
+            "PERF_CORE_FREQ_MHZ=${PERF_CORE_FREQ_MHZ}"
+            "PERF_UNCORE_FREQ_MHZ=${PERF_UNCORE_FREQ_MHZ}"
+        )
+
+        # Both tests pin CPU 1 with SCHED_FIFO and pin core/uncore frequency,
+        # so they must never run concurrently (RUN_SERIAL). Each gets its own
+        # RESULTS_DIR because every run deletes and rewrites distributions.csv
+        # in that directory.
+
+        # --- A/B perf test (all configs + page sizes in one run) ---
+        add_test(NAME perf COMMAND dto-test-perf)
+        set_tests_properties(perf PROPERTIES
+            LABELS "perf"
+            TIMEOUT 2400
+            RUN_SERIAL TRUE
+            ENVIRONMENT "RESULTS_DIR=${CMAKE_BINARY_DIR}/perf_results;${PERF_COMMON_ENV}"
+        )
+
+        # short sanity variant: memcpy 4k/64k/1m + memset 64k,
+        # few iterations. use -V to see the
+        # condensed speedup table
+        add_test(NAME sanity COMMAND dto-test-perf)
+        set_tests_properties(sanity PROPERTIES
+            LABELS "perf"
+            TIMEOUT 120
+            RUN_SERIAL TRUE
+            ENVIRONMENT "PERF_SHORT=1;RESULTS_DIR=${CMAKE_BINARY_DIR}/perf_results_sanity;${PERF_COMMON_ENV}"
+        )
+    else()
+        message(STATUS "perf test: disabled (requires DTO_ACCEL_CONFIG_SUPPORT and "
+                       "DTO_NUMA_SUPPORT; its A/B baseline is built from unguarded "
+                       "upstream sources)")
+    endif()
+endif()
+
 # Install and export the library
 install(TARGETS dto
         EXPORT DTOTargets
@@ -136,3 +254,4 @@ install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/DTOConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/DTOConfigVersion.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/DTO)
+

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,443 @@
+# DTO Test Suite
+
+## Prerequisites
+
+DSA hardware tests require configured work queues and hugepage allocation:
+
+```bash
+# Configure DSA (run your accel-config setup script)
+sudo ./accelConfig.sh 0 yes 0   # Example: 1 work queue, DSA0 enabled
+
+# Allocate hugepages for 2MB page tests
+sudo sh -c 'echo 128 > /proc/sys/vm/nr_hugepages'
+```
+
+## Build
+
+```bash
+cmake -B build -DDTO_BUILD_TESTS=ON
+cmake --build build
+cd build
+```
+
+To disable tests: `-DDTO_BUILD_TESTS=OFF`
+
+## Running Tests
+
+```bash
+# Run all tests (functional + perf)
+ctest
+
+# Functional tests only (no DSA hardware needed)
+ctest --label-regex functional
+
+# Performance tests only (requires DSA hardware)
+ctest --label-regex perf
+
+# Verbose output (shows stdout for all tests, not just failures)
+ctest -V
+
+# With output on failure only
+ctest --output-on-failure
+```
+
+## Test Labels
+
+| Label        | Description                            |
+|--------------|----------------------------------------|
+| `functional` | Correctness tests, no DSA needed       |
+| `perf`       | Performance benchmarks, requires DSA   |
+
+## Functional Tests
+
+Correctness tests for `memset`, `memcpy`, `memmove`, `memcmp` across buffer
+sizes spanning below and above the DSA offload threshold. Includes
+unaligned access and multithreaded tests. These pass with or without DSA
+hardware -- DTO falls back to CPU transparently.
+
+```bash
+ctest -R functional
+```
+
+## Performance Tests
+
+The performance test (`perf`) detects regressions in libdto by
+comparing a **baseline** build (from the `perf_baseline` branch on
+`github.com/intel/DTO`) against the **current** working tree, both
+statically linked into a single
+test binary. The test fails if any non-reference benchmark shows a trimmed
+mean latency increase exceeding the minimum effect threshold (default 2%).
+
+```bash
+ctest -R perf --output-on-failure
+```
+
+### Short Sanity Run (`sanity`)
+
+`sanity` runs a fast subset — memcpy 4k/64k/1m and memset 64k (no
+fault-injection variants), 100 iterations, a single A/B round. Used
+for quick debug testing only.
+
+```bash
+ctest -R sanity -V
+```
+
+Run with `-V` — CTest captures test output by default, so without it only
+pass/fail is shown; `-V` shows the per-page-size detail tables and the
+condensed speedup-vs-CPU summary. Both tests carry the `perf` label, so
+`ctest --label-regex perf` runs both; `ctest -R perf` runs only the full
+suite.
+
+### How It Works
+
+1. **Build phase** — CMake compiles two object files:
+   - `dto_current.o` from the working tree (`cur_memcpy`, `cur_memset`, ...)
+   - `dto_baseline.o` from the `perf_baseline` branch on `github.com/intel/DTO`
+     via `tests/build_baseline.sh` (`bl_memcpy`, `bl_memset`, ...)
+
+   Both use `objcopy --redefine-sym` so the two versions coexist in the same
+   binary with no symbol conflicts. The baseline is cached by git SHA and
+   only rebuilt when the upstream branch changes.
+
+2. **Measurement** — For each (benchmark × DTO config × page size) cell:
+   - Each cell runs `PERF_AB_ROUNDS` (default 3) forked child processes,
+     each executing 10,000 iterations (configurable via `DEFAULT_ITERS`).
+   - Each child runs with **randomized interleaving**: a xorshift32 PRNG
+     decides whether baseline or current runs first on each iteration,
+     eliminating first-mover bias.
+
+3. **Analysis** — Samples from all rounds are pooled, sorted, then:
+   - **Trimmed mean** (10th–90th percentile) computes the central tendency,
+     excluding outlier tails.
+   - **Kolmogorov–Smirnov test** on the trimmed distributions reports the
+     D statistic (max ECDF distance) and p-value as a distribution shape
+     diagnostic. Note: KS D is sensitive to distribution width, not just
+     shift—tight distributions can show large D for tiny absolute changes.
+   - **IQR-based outlier count** uses a shared threshold (Q3 + 1.5×IQR from
+     the combined baseline+current quartiles) to count outliers per version.
+   - **Pass/fail** is based solely on the trimmed mean change exceeding the
+     `PERF_MIN_EFFECT` threshold (default 2%).
+
+4. **Output** — Two detail tables (one per page size) show per-cell results,
+   followed by a speedup summary comparing each DTO config against raw CPU.
+   A `distributions.csv` file is written to `RESULTS_DIR` for offline
+   plotting with `tests/plot-distributions.{R,py}`.
+
+### A/B Fork Architecture
+
+The following diagram shows the full lifecycle of one cell (one benchmark ×
+DTO config × page size combination). The parent process orchestrates
+everything; each measurement round runs in a forked child that communicates
+results back through shared memory (`MAP_SHARED|MAP_ANONYMOUS`).
+
+```
+run_cell(benchmark, dto_config, page_config)
+│
+│   ┌─────────────────────────────────────────────────────────┐
+│   │  MEASUREMENT PHASE — ab_rounds forked children          │
+│   └─────────────────────────────────────────────────────────┘
+│
+├── iters = DEFAULT_ITERS (10,000)
+├── alloc pooled arrays: all_bl[rounds×iters], all_cur[rounds×iters]
+│
+├── for round = 0 .. ab_rounds-1:
+│   │
+│   ├── fork_ab(iters)
+│   │   │
+│   │   ├── [parent] setenv(DTO config vars: CSF, AAK, MIN_BYTES, etc.)
+│   │   ├── [parent] fork() ─────────────────────────────────────┐
+│   │   │                                                        │
+│   │   │   ┌────────────────────────────────────────────────────▼───┐
+│   │   │   │  CHILD PROCESS (pid == 0)                              │
+│   │   │   │                                                        │
+│   │   │   │  1. pthread_atfork child handler fires:                │
+│   │   │   │     └── dto.c:child() resets dto_initialized = 0       │
+│   │   │   │         and calls init_dto() which re-reads env vars,  │
+│   │   │   │         reopens DSA work queues, resets auto-tune state│
+│   │   │   │                                                        │
+│   │   │   │  2. Resolve function pointers:                         │
+│   │   │   │     ├── cpu config:  dlopen("libc.so.6") → dlsym       │
+│   │   │   │     │   a_memcpy = b_memcpy = libc memcpy (A==B)       │
+│   │   │   │     └── dto configs: a_* = bl_* (baseline symbols)     │
+│   │   │   │                      b_* = cur_* (current symbols)     │
+│   │   │   │                                                        │
+│   │   │   │  3. Initialize src[i] = i & 0xFF, dst = src            │
+│   │   │   │                                                        │
+│   │   │   │  4. Warmup (100 iters of both a and b)                 │
+│   │   │   │     └── primes IOTLB entries for DSA                   │
+│   │   │   │                                                        │
+│   │   │   │  5. Measurement loop (10,000 iters):                   │
+│   │   │   │     see "Measurement Loop Detail" below                │
+│   │   │   │                                                        │
+│   │   │   │  6. qsort(bl_samples), qsort(cur_samples)              │
+│   │   │   │  7. slot->nsamples, slot->ok = 1                       │
+│   │   │   │  8. _exit(0)                                           │
+│   │   │   └────────────────────────────────────────────────────────┘
+│   │   │
+│   │   ├── [parent] waitpid()
+│   │   └── [parent] unsetenv(DTO config vars)
+│   │
+│   └── [parent] memcpy child samples into pooled all_bl[], all_cur[]
+│
+│   ┌─────────────────────────────────────────────────────────┐
+│   │  ANALYSIS PHASE                                         │
+│   └─────────────────────────────────────────────────────────┘
+│
+├── qsort all_bl[], all_cur[]
+├── trimmed mean (10th–90th percentile) → bl_ns, cur_ns
+├── change = (cur_ns - bl_ns) / bl_ns × 100
+├── KS test on trimmed distributions → D statistic, p-value
+├── IQR outlier count (shared Q1/Q3 threshold)
+├── regression = change > min_effect (default 2%)
+└── append raw samples to distributions.csv
+```
+
+#### Measurement Loop Detail
+
+Each iteration measures both baseline and current with randomized ordering
+to eliminate first-mover bias (e.g., DSA engine idle advantage).
+
+```
+seed rng = rdtsc() | 1          ← nonzero seed for xorshift32
+
+for i = 0 .. iters-1:
+│
+├── xorshift32(rng) → bl_first = (rng & 1)
+│
+│   ┌── Measure FIRST  ──────────────────────────────┐
+│   │ if cold_cache: clflushopt(src), clflushopt(dst)│
+│   │ lfence                                         │
+│   │ start = rdtsc                                  │
+│   │ execute (bl_first ? BASELINE : CURRENT)        │
+│   │ COMPILER_BARRIER                               │
+│   │ end = rdtscp                                   │
+│   └────────────────────────────────────────────────┘
+│
+│   (memcmp: reset dst = src)
+│
+│   ┌── Measure SECOND  ─────────────────────────────┐
+│   │ if cold_cache: clflushopt(src), clflushopt(dst)│
+│   │ lfence                                         │
+│   │ start = rdtsc                                  │
+│   │ execute (bl_first ? CURRENT : BASELINE)        │
+│   │ COMPILER_BARRIER                               │
+│   │ end = rdtscp                                   │
+│   └────────────────────────────────────────────────┘
+│
+├── bl_samples[i] = t_bl
+└── cur_samples[i] = t_cur
+```
+
+#### Shared Memory Layout
+
+The parent allocates one shared memory region (`MAP_SHARED|MAP_ANONYMOUS`)
+used by all children sequentially. The child writes directly to this
+region; the parent reads it after `waitpid()` returns.
+
+```
+shm ── ┌──────────────────────────────────────┐
+       │ struct shared_result                 │
+       │   .ok              (child sets to 1) │
+       │   .nsamples        (actual count)    │
+       │   .requested_iters (parent sets)     │
+       ├──────────────────────────────────────┤
+       │ bl_samples[0..DEFAULT_ITERS-1]       │
+       │   (baseline cycle counts, uint64_t)  │
+       ├──────────────────────────────────────┤
+       │ cur_samples[0..DEFAULT_ITERS-1]      │
+       │   (current cycle counts, uint64_t)   │
+       └──────────────────────────────────────┘
+
+src ── ┌──────────────────────────────────────┐
+       │ Source buffer (MAP_SHARED)           │
+       │ 4KB pages or 2MB hugepages           │
+       └──────────────────────────────────────┘
+
+dst ── ┌──────────────────────────────────────┐
+       │ Destination buffer (MAP_SHARED)      │
+       │ 4KB pages or 2MB hugepages           │
+       └──────────────────────────────────────┘
+```
+
+All buffers use `MAP_SHARED` so the child (a separate process after `fork()`)
+operates on the same physical pages as the parent. This avoids copy-on-write
+faults during measurement that would add noise.
+
+### Noise Reduction
+
+The test applies several techniques for stable, reproducible measurements:
+
+- **CPU pinning** (`sched_setaffinity`) to a single core (default core 1)
+- **Core and uncore frequency pinning** via sysfs (requires root)
+- **Cold-cache** benchmarking with `clflushopt` before each iteration (default)
+- **Process isolation** via `fork()` — each A/B round runs in a child process,
+  triggering DTO's `pthread_atfork` handler to reinitialize DSA state
+- **Static linking** — both DTO versions share the same code layout, eliminating
+  noise from separate shared library mappings
+- **Randomized A/B order** — eliminates systematic first-mover advantage
+  (e.g., idle DSA engine bias)
+
+### Test Modes
+
+Four DTO configurations isolate different code paths:
+
+| Config     | What it Measures                                         |
+|------------|----------------------------------------------------------|
+| `cpu`      | Raw libc (via `dlsym`), no DTO — reference baseline      |
+| `stdc`     | DTO linked, forced CPU path (`DTO_USESTDC_CALLS=1`)      |
+| `dsa`      | Pure DSA through DTO (`CSF=0`, no auto-tuning)           |
+| `dsa_auto` | DSA with runtime auto-tuning (`CSF=0` start, `DTO_AUTO_ADJUST_KNOBS=1`) |
+
+Each config is tested with both **4KB pages** and **2MB hugepages**.
+
+DSA-enabled modes set `DTO_MIN_BYTES=4096` so DSA is exercised for all buffer
+sizes in the benchmark.
+
+### Benchmarked Operations
+
+| Benchmark     | Size    | Pass/Fail |
+|---------------|---------|-----------|
+| `memcpy_4k`   | 4 KB    | Reference only (high CV at small sizes) |
+| `memcpy_8k`   | 8 KB    | Reference only |
+| `memcpy_16k`  | 16 KB   | Yes |
+| `memcpy_32k`  | 32 KB   | Yes |
+| `memcpy_64k`  | 64 KB   | Yes |
+| `memcpy_128k` | 128 KB  | Yes |
+| `memcpy_256k` | 256 KB  | Yes |
+| `memcpy_512k` | 512 KB  | Yes |
+| `memcpy_1m`   | 1 MB    | Yes |
+| `memcpy_1m_pf50` | 1 MB | Yes (50% of ops fault a single page) |
+| `memset_64k`  | 64 KB   | Yes |
+| `memset_128k` | 128 KB  | Yes |
+| `memset_256k` | 256 KB  | Yes |
+| `memset_1m`   | 1 MB    | Yes |
+| `memcmp_64k`  | 64 KB   | Yes |
+| `memcmp_128k` | 128 KB  | Yes |
+| `memcmp_1m`   | 1 MB    | Yes |
+
+The `_pf50` suffix is the page-fault probability (`pf_pct`) for the operation.
+It is evaluated before **each** measured operation. For example, in the 50% test
+case, half of all operations will have a random page of the destination
+buffer is dropped via `madvise(MADV_DONTNEED)`. The operation then takes one
+minor page fault when it next touches that page.
+
+Only one page is faulted per operation for now. Note the granularity is the
+mapping's page size, so under 4 KB pages a single 4 KB page is dropped, whereas
+under 2 MB hugepages the one dropped page is the whole 2 MB huge page.
+
+### Example Output
+
+Note: Your numbers will differ based on hardware, kernel, and DSA
+configuration.
+
+```
+DTO A/B Performance Test (cold cache)
+================================================
+Pinned CPU:    1
+TSC freq:      2.000 GHz
+Core freq:     2000 MHz (min=2000 max=2000) [pinned]
+Uncore freq:   min=2000 max=2000 MHz [pinned]
+A/B rounds:    3 (interleaved, randomized order)
+Min effect:    2.0%
+
+  ===============================================
+  A/B Results — 4KB pages
+  ===============================================
+  Test          Config    Base mean   Cur mean Change    KS D    Result    Outliers
+  ------------- --------- ---------   --------- -------- -----   -------   --------
+  memcpy_16k    cpu        4033 ns     4036 ns   +0.1%   0.026   PASS      bl=5 cur=3
+                stdc       4035 ns     4034 ns   -0.0%   0.021   PASS      bl=4 cur=6
+                dsa        1520 ns     1518 ns   -0.1%   0.018   PASS      bl=2 cur=3
+                dsa_auto   1680 ns     1675 ns   -0.3%   0.031   PASS      bl=8 cur=5
+  ...
+
+  ===============================================
+  Speedup vs CPU (current library)
+  ===============================================
+
+  4KB pages:
+  Test                stdc     dsa       dsa_auto
+  --------------  ---------- ---------- ----------
+  memcpy_16k          1.00x     2.66x     2.41x
+  ...
+```
+
+### Plotting Distributions
+
+The test writes raw sample data to `distributions.csv`. Two equivalent scripts
+generate density, violin, and ECDF plots for each operation — an R version and
+a Python port. Both take the same positional arguments:
+
+```
+plot-distributions.{R,py} [results_dir] [pagesize] [optype]
+  results_dir - directory containing distributions.csv (default: build/perf_results)
+  pagesize    - 4k or 2m (default: 4k)
+  optype      - memcpy, memset, or memcmp (default: memcpy)
+```
+
+```bash
+cd build
+
+# R version (requires ggplot2, dplyr)
+Rscript ../tests/plot-distributions.R perf_results 4k memcpy
+
+# Python port (requires pandas, numpy, matplotlib, scipy)
+python3 ../tests/plot-distributions.py perf_results 4k memcpy
+```
+
+Both write `distributions_{pagesize}_{optype}_{density,violin,ecdf}.png` into
+`results_dir`.
+
+### Baseline Management
+
+The baseline is built automatically from the `perf_baseline` branch on
+`github.com/intel/DTO` during `cmake --build`. The build script
+(`tests/build_baseline.sh`):
+
+- Fetches the upstream branch and checks the SHA
+- Skips the build if the cached `dto_baseline.o` matches the current SHA
+- Creates a temporary git worktree to compile the baseline source
+- Compiles with the same flags as the current build (`-O3 -DNDEBUG -march=native`)
+- Renames symbols via `objcopy` (`memcpy` → `bl_memcpy`, etc.)
+- Cleans up the worktree after building
+
+To force a baseline rebuild, delete `build/perf_baseline/dto_baseline.o` and
+rebuild.
+
+### Environment Variables
+
+| Variable            | Default                                | Effect                                             |
+|---------------------|----------------------------------------|----------------------------------------------------|
+| `PERF_CPU`             | `1`                                 | CPU core to pin the benchmark thread to            |
+| `PERF_CORE_FREQ_MHZ`   | `2000`                              | Pin core frequency (MHz); requires root            |
+| `PERF_UNCORE_FREQ_MHZ` | `2000`                              | Pin uncore frequency (MHz); requires root          |
+| `PERF_MIN_EFFECT`   | `2`                                    | Minimum trimmed mean change % to flag a FAIL       |
+| `PERF_AB_ROUNDS`    | `3`                                    | Number of interleaved A/B fork rounds              |
+| `PERF_ITERS`        | `10000` 		                | Iterations per A/B round (capped at 10000)         |
+| `PERF_SHORT`        | `0`                                    | 1 = fast sanity subset (see `sanity` above)   |
+| `PERF_COLD_CACHE`   | `1`                                    | 1 = `clflushopt` per iteration, 0 = flush once     |
+| `RESULTS_DIR`       |  ${CMAKE_BINARY_DIR}/perf_results      | Directory for `distributions.csv` output           |
+
+CMake sets `RESULTS_DIR`, `PERF_CORE_FREQ_MHZ`, and `PERF_UNCORE_FREQ_MHZ`
+automatically when running via CTest. The `perf` and `sanity` tests get
+separate results directories (`perf_results` and `perf_results_sanity`)
+because each run deletes and rewrites `distributions.csv` in its directory. Override either at configure time (they
+are independent, so core and uncore can be pinned to different frequencies):
+
+```bash
+cmake -B build -DDTO_BUILD_TESTS=ON -DPERF_CORE_FREQ_MHZ=2400 -DPERF_UNCORE_FREQ_MHZ=2000
+```
+
+### Pin to a Different CPU Core
+
+```bash
+PERF_CPU=3 ctest -R perf
+```
+
+### Adjust Regression Threshold
+
+Default is 2%. To relax (e.g., on noisy systems):
+
+```bash
+PERF_MIN_EFFECT=5 ctest -R perf
+```

--- a/tests/build_baseline.sh
+++ b/tests/build_baseline.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Build the baseline dto_baseline.o from the baseline branch.
+# Compiles dto.c to an object file and renames the 4 public symbols
+# (memcpy/memset/memcmp/memmove → bl_*) so it can be statically linked
+# alongside the current version in the same binary.
+#
+# Usage: build_baseline.sh <source_dir> <output_dir> [c_compiler] [cflags...]
+#   source_dir  - root of the DTO repo (for git operations)
+#   output_dir  - where to put dto_baseline.o
+#   c_compiler  - C compiler to use (defaults to gcc); pass CMAKE_C_COMPILER so
+#                 the baseline object is built with the same compiler as the
+#                 current object it is A/B-compared against.
+#   cflags...   - compile flags (defines, -march, -mwaitpkg, ...); pass the same
+#                 flags used for the current object so the A/B comparison is
+#                 apples-to-apples. Defaults to a sensible set if omitted.
+
+set -e
+
+SOURCE_DIR="$1"
+OUTPUT_DIR="$2"
+CC="${3:-gcc}"
+CFLAGS_EXTRA=("${@:4}")
+if [ ${#CFLAGS_EXTRA[@]} -eq 0 ]; then
+    CFLAGS_EXTRA=(-O3 -DNDEBUG -march=native -fPIC
+                 -D_GNU_SOURCE -DDTO_STATS_SUPPORT
+                 -DDTO_ACCEL_CONFIG_SUPPORT -DDTO_NUMA_SUPPORT)
+fi
+BASELINE_OBJ="${OUTPUT_DIR}/dto_baseline.o"
+WORKTREE_DIR="${OUTPUT_DIR}/baseline_worktree"
+UPSTREAM_URL="https://github.com/intel/DTO.git"
+BRANCH="perf_baseline"
+
+mkdir -p "${OUTPUT_DIR}"
+
+# Skip if baseline already built and up-to-date
+if [ -f "${BASELINE_OBJ}" ]; then
+    cd "${SOURCE_DIR}"
+    timeout 20 git fetch "${UPSTREAM_URL}" "${BRANCH}" --quiet 2>/dev/null || true
+    REMOTE_SHA=$(git rev-parse FETCH_HEAD 2>/dev/null || echo "unknown")
+    BUILT_SHA=""
+    if [ -f "${OUTPUT_DIR}/baseline_sha" ]; then
+        BUILT_SHA=$(cat "${OUTPUT_DIR}/baseline_sha")
+    fi
+    if [ "${REMOTE_SHA}" = "${BUILT_SHA}" ]; then
+        echo "Baseline dto_baseline.o is up-to-date (${UPSTREAM_URL} ${BRANCH} = ${REMOTE_SHA:0:12})"
+        exit 0
+    fi
+    if [ "${REMOTE_SHA}" = "unknown" ]; then
+        # Offline / upstream unreachable but a cached baseline exists: reuse it
+        # rather than aborting the whole build on the fetch below.
+        echo "WARNING: cannot reach ${UPSTREAM_URL}; reusing cached ${BASELINE_OBJ}" >&2
+        exit 0
+    fi
+    echo "Baseline outdated, rebuilding..."
+fi
+
+# Clean up any previous worktree
+if [ -d "${WORKTREE_DIR}" ]; then
+    cd "${SOURCE_DIR}"
+    git worktree remove --force "${WORKTREE_DIR}" 2>/dev/null || rm -rf "${WORKTREE_DIR}"
+fi
+
+# Create a worktree at the baseline branch
+cd "${SOURCE_DIR}"
+if ! git fetch "${UPSTREAM_URL}" "${BRANCH}" --quiet; then
+    echo "ERROR: failed to fetch ${BRANCH} from ${UPSTREAM_URL}" >&2
+    if [ -f "${BASELINE_OBJ}" ]; then
+        echo "Reusing existing ${BASELINE_OBJ}" >&2
+        exit 0
+    fi
+    exit 1
+fi
+echo "Building baseline from ${UPSTREAM_URL} ${BRANCH}..."
+git worktree add --detach "${WORKTREE_DIR}" FETCH_HEAD
+
+# Compile to object file with the same flags as the current object
+"${CC}" -c "${CFLAGS_EXTRA[@]}" \
+    "${WORKTREE_DIR}/dto.c" -o "${OUTPUT_DIR}/dto_baseline_raw.o" \
+    >>"${OUTPUT_DIR}/build.log" 2>&1
+
+# Rename public symbols: memcpy→bl_memcpy, etc.
+objcopy --redefine-sym memcpy=bl_memcpy \
+        --redefine-sym memset=bl_memset \
+        --redefine-sym memcmp=bl_memcmp \
+        --redefine-sym memmove=bl_memmove \
+        "${OUTPUT_DIR}/dto_baseline_raw.o" "${BASELINE_OBJ}"
+
+rm -f "${OUTPUT_DIR}/dto_baseline_raw.o"
+
+# Record the SHA we built
+BUILT_SHA=$(git rev-parse FETCH_HEAD)
+echo "${BUILT_SHA}" > "${OUTPUT_DIR}/baseline_sha"
+
+# Clean up worktree
+cd "${SOURCE_DIR}"
+git worktree remove --force "${WORKTREE_DIR}" 2>/dev/null || true
+
+echo "Baseline built: ${BASELINE_OBJ} (${UPSTREAM_URL} ${BRANCH} = ${BUILT_SHA:0:12})"

--- a/tests/dto_test_utils.h
+++ b/tests/dto_test_utils.h
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * dto_test_utils.h - Lightweight test utilities for DTO test suite.
+ *
+ * Provides:
+ *   - Assertion macros (return 1 from calling function on failure)
+ *   - Test runner with pass/fail reporting
+ *   - Timing helpers for performance benchmarks
+ *   - Baseline load/save for performance regression testing
+ ******************************************************************************/
+
+#ifndef DTO_TEST_UTILS_H
+#define DTO_TEST_UTILS_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <stdint.h>
+
+/* ---- Assertion macros ---- */
+
+#define ASSERT_TRUE(cond) do { \
+	if (!(cond)) { \
+		fprintf(stderr, "    FAIL: %s (at %s:%d)\n", \
+			#cond, __FILE__, __LINE__); \
+		return 1; \
+	} \
+} while (0)
+
+#define ASSERT_EQ(a, b) do { \
+	long long _a = (long long)(a), _b = (long long)(b); \
+	if (_a != _b) { \
+		fprintf(stderr, "    FAIL: %s == %s (%lld != %lld) at %s:%d\n", \
+			#a, #b, _a, _b, __FILE__, __LINE__); \
+		return 1; \
+	} \
+} while (0)
+
+/* ---- Test runner ---- */
+
+typedef int (*test_fn)(void);
+
+struct dto_test {
+	const char *name;
+	test_fn fn;
+};
+
+#define TEST_ENTRY(fn) { #fn, fn }
+
+static inline int run_tests(struct dto_test *tests)
+{
+	int total = 0, passed = 0, failed = 0;
+
+	for (int i = 0; tests[i].name != NULL; i++) {
+		total++;
+		printf("  %-50s ", tests[i].name);
+		fflush(stdout);
+		if (tests[i].fn() == 0) {
+			printf("PASS\n");
+			passed++;
+		} else {
+			printf("FAIL\n");
+			failed++;
+		}
+	}
+
+	printf("\nResults: %d/%d passed", passed, total);
+	if (failed > 0)
+		printf(" (%d FAILED)", failed);
+	printf("\n");
+
+	return failed > 0 ? 1 : 0;
+}
+
+/* ---- Timing helpers ---- */
+
+static inline uint64_t time_ns(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+}
+
+/* Prevent dead code elimination of benchmark operations */
+#define COMPILER_BARRIER() __asm__ volatile("" ::: "memory")
+
+/* ---- Aligned allocation ---- */
+
+static inline void *alloc_aligned(size_t size)
+{
+	void *ptr = NULL;
+
+	if (posix_memalign(&ptr, 4096, size) != 0)
+		return NULL;
+	return ptr;
+}
+
+/* ---- Performance baseline support ---- */
+
+#define MAX_BASELINES 64
+#define BASELINE_NAME_LEN 64
+
+struct perf_baseline {
+	char name[BASELINE_NAME_LEN];
+	double latency_ns;
+};
+
+static inline int load_baselines(const char *path,
+				 struct perf_baseline *baselines, int max)
+{
+	FILE *f = fopen(path, "r");
+	int count = 0;
+	char line[256];
+
+	if (!f)
+		return 0;
+
+	while (fgets(line, sizeof(line), f) && count < max) {
+		if (line[0] == '#' || line[0] == '\n')
+			continue;
+		if (sscanf(line, "%63s %lf", baselines[count].name,
+			   &baselines[count].latency_ns) == 2)
+			count++;
+	}
+	fclose(f);
+	return count;
+}
+
+static inline int save_baselines(const char *path,
+				 struct perf_baseline *baselines, int count)
+{
+	FILE *f = fopen(path, "w");
+	time_t now;
+
+	if (!f) {
+		fprintf(stderr, "Failed to open %s for writing\n", path);
+		return 1;
+	}
+
+	now = time(NULL);
+	fprintf(f, "# DTO Performance Baselines (latency in ns)\n");
+	fprintf(f, "# Re-generate with: UPDATE_BASELINES=1 ctest --label-regex perf\n");
+	fprintf(f, "# Generated: %s", ctime(&now));
+	for (int i = 0; i < count; i++)
+		fprintf(f, "%-24s %.1f\n", baselines[i].name,
+			baselines[i].latency_ns);
+
+	fclose(f);
+	return 0;
+}
+
+static inline double find_baseline(struct perf_baseline *baselines, int count,
+				   const char *name)
+{
+	for (int i = 0; i < count; i++) {
+		if (strcmp(baselines[i].name, name) == 0)
+			return baselines[i].latency_ns;
+	}
+	return -1.0;
+}
+
+#endif /* DTO_TEST_UTILS_H */

--- a/tests/plot-distributions.R
+++ b/tests/plot-distributions.R
@@ -1,0 +1,110 @@
+#!/usr/bin/env Rscript
+# Plot baseline vs current latency distributions from perf output.
+#
+# Usage: Rscript tests/plot-distributions.R [results_dir] [pagesize]
+#   results_dir - directory with distributions_*.csv (default: build/perf_results)
+#   pagesize    - "4k" or "2m" (default: "4k")
+#
+# Generates:
+#   distributions_{pagesize}_density.png  - overlaid density curves
+#   distributions_{pagesize}_violin.png   - violin plots per test/config
+#   distributions_{pagesize}_ecdf.png     - empirical CDF (most sensitive)
+
+library(ggplot2)
+library(dplyr)
+
+args <- commandArgs(trailingOnly = TRUE)
+results_dir <- if (length(args) >= 1) args[1] else "build/perf_results"
+pagesize    <- if (length(args) >= 2) args[2] else "4k"
+optype    <- if (length(args) >= 3) args[3] else "memcpy"
+
+csv_path <- file.path(results_dir, "distributions.csv")
+if (!file.exists(csv_path)) {
+  stop("CSV not found: ", csv_path,
+       "\nRun: ctest -R perf --output-on-failure")
+}
+
+d <- read.csv(csv_path, stringsAsFactors = FALSE)
+
+# Filter to requested pagesize and op type
+d <- d[d$pagesize == pagesize, ]
+d <- d[grepl(paste("^",optype,sep=""), d$test), ]
+if (nrow(d) == 0) {
+  stop("No data for pagesize '", pagesize, "' in ", csv_path)
+}
+cat("Loaded", nrow(d), "samples from", csv_path, "\n")
+
+# Trim outliers per group (keep 1st-99th percentile) for cleaner plots
+d <- d %>%
+  group_by(test, config, version) %>%
+  filter(latency_ns >= quantile(latency_ns, 0.01),
+         latency_ns <= quantile(latency_ns, 0.99)) %>%
+  ungroup()
+
+d$version <- factor(d$version, levels = c("baseline", "current"))
+d$config  <- factor(d$config, levels = c("cpu", "stdc", "dsa", "dsa_auto"))
+
+# Compute median per group for annotation
+medians <- d %>%
+  group_by(test, config, version) %>%
+  summarise(med = median(latency_ns), .groups = "drop")
+
+# --- 1. Density plot: overlaid distributions ---
+p1 <- ggplot(d, aes(x = latency_ns, fill = version, color = version)) +
+  geom_density(alpha = 0.3, linewidth = 0.5) +
+  geom_vline(data = medians, aes(xintercept = med, color = version),
+             linetype = "dashed", linewidth = 0.4) +
+  facet_wrap(~ test + config, scales = "free", ncol = 3,
+             labeller = labeller(.multi_line = FALSE)) +
+  scale_fill_manual(values = c(baseline = "#2166ac", current = "#b2182b")) +
+  scale_color_manual(values = c(baseline = "#2166ac", current = "#b2182b")) +
+  labs(title = paste("Latency Distributions: Baseline vs Current (", pagesize, ",", optype, ")"),
+       x = "Latency (ns)", y = "Density",
+       fill = "Version", color = "Version") +
+  theme_minimal(base_size = 10) +
+  theme(strip.text = element_text(face = "bold", size = 7),
+        legend.position = "bottom",
+        axis.text.x = element_text(angle = 45, hjust = 1))
+
+outfile <- file.path(results_dir,
+                     paste0("distributions_", pagesize, "_", optype, "_density.png"))
+ggsave(outfile, p1, width = 16, height = 20, dpi = 150)
+cat("Saved", outfile, "\n")
+
+# --- 2. Violin plot: shape comparison ---
+p2 <- ggplot(d, aes(x = version, y = latency_ns, fill = version)) +
+  geom_violin(alpha = 0.6, draw_quantiles = c(0.25, 0.5, 0.75)) +
+  facet_wrap(~ test + config, scales = "free_y", ncol = 3,
+             labeller = labeller(.multi_line = FALSE)) +
+  scale_fill_manual(values = c(baseline = "#2166ac", current = "#b2182b")) +
+  labs(title = paste("Latency Violins: Baseline vs Current (", pagesize, ",", optype, ")"),
+       x = "", y = "Latency (ns)") +
+  theme_minimal(base_size = 10) +
+  theme(strip.text = element_text(face = "bold", size = 7),
+        legend.position = "none")
+
+outfile <- file.path(results_dir,
+                     paste0("distributions_", pagesize, "_", optype, "_violin.png"))
+ggsave(outfile, p2, width = 16, height = 20, dpi = 150)
+cat("Saved", outfile, "\n")
+
+# --- 3. ECDF plot: most sensitive to distribution shifts ---
+p3 <- ggplot(d, aes(x = latency_ns, color = version)) +
+  stat_ecdf(linewidth = 0.5) +
+  facet_wrap(~ test + config, scales = "free_x", ncol = 3,
+             labeller = labeller(.multi_line = FALSE)) +
+  scale_color_manual(values = c(baseline = "#2166ac", current = "#b2182b")) +
+  labs(title = paste("Empirical CDF: Baseline vs Current (", pagesize, "," , optype, ")"),
+       x = "Latency (ns)", y = "Cumulative Probability",
+       color = "Version") +
+  theme_minimal(base_size = 10) +
+  theme(strip.text = element_text(face = "bold", size = 7),
+        legend.position = "bottom",
+        axis.text.x = element_text(angle = 45, hjust = 1))
+
+outfile <- file.path(results_dir,
+                     paste0("distributions_", pagesize, "_", optype, "_ecdf.png"))
+ggsave(outfile, p3, width = 16, height = 20, dpi = 150)
+cat("Saved", outfile, "\n")
+
+cat("\nDone. All plots in", results_dir, "\n")

--- a/tests/plot-distributions.py
+++ b/tests/plot-distributions.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# Plot baseline vs current latency distributions from perf output.
+#
+# Python port of plot-distributions.R (identical inputs, outputs, and file
+# names). Requires: pandas, numpy, matplotlib, scipy.
+#   pip install pandas numpy matplotlib scipy
+#
+# Usage: python3 tests/plot-distributions.py [results_dir] [pagesize] [optype]
+#   results_dir - directory with distributions.csv (default: build/perf_results)
+#   pagesize    - "4k" or "2m" (default: "4k")
+#   optype      - "memcpy", "memset", or "memcmp" (default: "memcpy")
+#
+# Generates:
+#   distributions_{pagesize}_{optype}_density.png  - overlaid density curves
+#   distributions_{pagesize}_{optype}_violin.png   - violin plots per test/config
+#   distributions_{pagesize}_{optype}_ecdf.png     - empirical CDF (most sensitive)
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+from scipy.stats import gaussian_kde
+
+import matplotlib
+matplotlib.use("Agg")  # headless / CI-safe
+import matplotlib.pyplot as plt
+
+# Match the R script's palette and category ordering.
+COLORS = {"baseline": "#2166ac", "current": "#b2182b"}
+VERSION_ORDER = ["baseline", "current"]
+CONFIG_ORDER = ["cpu", "stdc", "dsa", "dsa_auto"]
+NCOL = 3
+
+
+def main():
+    results_dir = sys.argv[1] if len(sys.argv) >= 2 else "build/perf_results"
+    pagesize = sys.argv[2] if len(sys.argv) >= 3 else "4k"
+    optype = sys.argv[3] if len(sys.argv) >= 4 else "memcpy"
+
+    csv_path = os.path.join(results_dir, "distributions.csv")
+    if not os.path.isfile(csv_path):
+        sys.exit("CSV not found: {}\nRun: ctest -R perf "
+                 "--output-on-failure".format(csv_path))
+
+    d = pd.read_csv(csv_path)
+
+    # Filter to requested pagesize and op type.
+    d = d[d["pagesize"] == pagesize]
+    d = d[d["test"].str.startswith(optype)]
+    if len(d) == 0:
+        sys.exit("No data for pagesize '{}' in {}".format(pagesize, csv_path))
+    print("Loaded {} samples from {}".format(len(d), csv_path))
+
+    # Trim outliers per group (keep 1st-99th percentile) for cleaner plots.
+    grp = d.groupby(["test", "config", "version"])["latency_ns"]
+    lo = grp.transform(lambda x: x.quantile(0.01))
+    hi = grp.transform(lambda x: x.quantile(0.99))
+    d = d[(d["latency_ns"] >= lo) & (d["latency_ns"] <= hi)].reset_index(drop=True)
+
+    # Deterministic facet order: by test (as encountered), then config order.
+    tests = list(dict.fromkeys(d["test"]))
+    facets = [(t, c) for t in tests for c in CONFIG_ORDER
+              if not d[(d["test"] == t) & (d["config"] == c)].empty]
+
+    _plot_density(d, facets, results_dir, pagesize, optype)
+    _plot_violin(d, facets, results_dir, pagesize, optype)
+    _plot_ecdf(d, facets, results_dir, pagesize, optype)
+
+    print("\nDone. All plots in {}".format(results_dir))
+
+
+def _make_grid(n):
+    nrow = (n + NCOL - 1) // NCOL
+    fig, axes = plt.subplots(nrow, NCOL, figsize=(16, 20), squeeze=False)
+    flat = [ax for row in axes for ax in row]
+    for ax in flat[n:]:          # hide unused cells
+        ax.axis("off")
+    return fig, flat
+
+
+def _group(d, test, config, version):
+    return d[(d["test"] == test) & (d["config"] == config)
+             & (d["version"] == version)]["latency_ns"].to_numpy()
+
+
+def _save(fig, results_dir, pagesize, optype, kind):
+    # Reserve a strip at top for the suptitle and at bottom for the legend.
+    fig.tight_layout(rect=(0, 0.03, 1, 0.98))
+    outfile = os.path.join(
+        results_dir,
+        "distributions_{}_{}_{}.png".format(pagesize, optype, kind))
+    fig.savefig(outfile, dpi=150)
+    plt.close(fig)
+    print("Saved {}".format(outfile))
+
+
+def _plot_density(d, facets, results_dir, pagesize, optype):
+    fig, axes = _make_grid(len(facets))
+    for ax, (test, config) in zip(axes, facets):
+        for version in VERSION_ORDER:
+            vals = _group(d, test, config, version)
+            if len(vals) == 0:
+                continue
+            color = COLORS[version]
+            if len(np.unique(vals)) >= 2:
+                kde = gaussian_kde(vals)
+                xs = np.linspace(vals.min(), vals.max(), 512)
+                ys = kde(xs)
+                ax.fill_between(xs, ys, alpha=0.3, color=color)
+                ax.plot(xs, ys, color=color, linewidth=0.5, label=version)
+            # dashed median line
+            ax.axvline(np.median(vals), color=color, linestyle="--",
+                       linewidth=0.4)
+        ax.set_title("{} {}".format(test, config), fontsize=7,
+                     fontweight="bold")
+        ax.set_xlabel("Latency (ns)", fontsize=7)
+        ax.set_ylabel("Density", fontsize=7)
+        ax.tick_params(axis="x", labelrotation=45, labelsize=6)
+        ax.tick_params(axis="y", labelsize=6)
+    _legend(fig)
+    fig.suptitle("Latency Distributions: Baseline vs Current "
+                 "( {} , {} )".format(pagesize, optype), fontsize=12)
+    _save(fig, results_dir, pagesize, optype, "density")
+
+
+def _plot_violin(d, facets, results_dir, pagesize, optype):
+    fig, axes = _make_grid(len(facets))
+    for ax, (test, config) in zip(axes, facets):
+        data, positions, colors = [], [], []
+        for i, version in enumerate(VERSION_ORDER, start=1):
+            vals = _group(d, test, config, version)
+            if len(vals) == 0:
+                continue
+            data.append(vals)
+            positions.append(i)
+            colors.append(COLORS[version])
+        if data:
+            parts = ax.violinplot(data, positions=positions, showextrema=False,
+                                  quantiles=[[0.25, 0.5, 0.75]] * len(data))
+            for body, color in zip(parts["bodies"], colors):
+                body.set_facecolor(color)
+                body.set_alpha(0.6)
+            if "cquantiles" in parts:
+                parts["cquantiles"].set_color("black")
+                parts["cquantiles"].set_linewidth(0.6)
+        ax.set_xticks([1, 2])
+        ax.set_xticklabels(VERSION_ORDER, fontsize=7)
+        ax.set_title("{} {}".format(test, config), fontsize=7,
+                     fontweight="bold")
+        ax.set_ylabel("Latency (ns)", fontsize=7)
+        ax.tick_params(axis="y", labelsize=6)
+    fig.suptitle("Latency Violins: Baseline vs Current "
+                 "( {} , {} )".format(pagesize, optype), fontsize=12)
+    _save(fig, results_dir, pagesize, optype, "violin")
+
+
+def _plot_ecdf(d, facets, results_dir, pagesize, optype):
+    fig, axes = _make_grid(len(facets))
+    for ax, (test, config) in zip(axes, facets):
+        for version in VERSION_ORDER:
+            vals = _group(d, test, config, version)
+            if len(vals) == 0:
+                continue
+            xs = np.sort(vals)
+            ys = np.arange(1, len(xs) + 1) / len(xs)
+            ax.step(xs, ys, where="post", color=COLORS[version],
+                    linewidth=0.5, label=version)
+        ax.set_title("{} {}".format(test, config), fontsize=7,
+                     fontweight="bold")
+        ax.set_xlabel("Latency (ns)", fontsize=7)
+        ax.set_ylabel("Cumulative Probability", fontsize=7)
+        ax.tick_params(axis="x", labelrotation=45, labelsize=6)
+        ax.tick_params(axis="y", labelsize=6)
+    _legend(fig)
+    fig.suptitle("Empirical CDF: Baseline vs Current "
+                 "( {} , {} )".format(pagesize, optype), fontsize=12)
+    _save(fig, results_dir, pagesize, optype, "ecdf")
+
+
+def _legend(fig):
+    handles = [plt.Line2D([0], [0], color=COLORS[v], lw=2, label=v)
+               for v in VERSION_ORDER]
+    fig.legend(handles=handles, loc="lower center", ncol=2,
+               title="Version", frameon=False, bbox_to_anchor=(0.5, 0.0))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_functional.c
+++ b/tests/test_functional.c
@@ -1,0 +1,502 @@
+/*******************************************************************************
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * test_functional.c - Functional correctness tests for DTO.
+ *
+ * Tests memset, memcpy, memmove, memcmp across a range of buffer sizes
+ * spanning below and above the DSA offload threshold (64KB default).
+ *
+ * When linked against libdto, these functions are intercepted by DTO.
+ * In CI (no DSA hardware), DTO falls back to the CPU path transparently.
+ * All tests should pass regardless of whether DSA hardware is present.
+ *
+ * Verification is done byte-by-byte to avoid relying on DTO's own memcmp
+ * for checking results.
+ *
+ * Labels: functional (safe to run in GitHub Actions without DSA)
+ ******************************************************************************/
+
+#include "dto_test_utils.h"
+#include <stdint.h>
+#include <pthread.h>
+
+/* Buffer sizes spanning below and above the DSA threshold (65536) */
+static const size_t test_sizes[] = {
+	0, 1, 7, 15, 16, 31, 32, 63, 64,
+	127, 128, 255, 256, 511, 512, 1023, 1024,
+	4096, 8192, 16384, 32768,
+	65536,		/* DTO_DEFAULT_MIN_SIZE - DSA threshold */
+	131072,		/* 128K - above threshold, triggers DSA */
+	262144,		/* 256K */
+};
+#define NUM_SIZES (sizeof(test_sizes) / sizeof(test_sizes[0]))
+#define MAX_SIZE 262144
+
+/*
+ * Helper functions for verification.
+ *
+ * These use byte-by-byte loops so the compiler cannot optimize them
+ * into memset/memcmp calls (which would be intercepted by DTO, defeating
+ * the purpose of independent verification).
+ */
+static int __attribute__((optimize("no-tree-loop-distribute-patterns")))
+verify_set(const uint8_t *buf, uint8_t val, size_t n)
+{
+	for (size_t i = 0; i < n; i++) {
+		if (buf[i] != val) {
+			fprintf(stderr, "    byte[%zu] = 0x%02x, expected 0x%02x\n",
+				i, buf[i], val);
+			return 0;
+		}
+	}
+	return 1;
+}
+
+static int __attribute__((optimize("no-tree-loop-distribute-patterns")))
+verify_equal(const uint8_t *a, const uint8_t *b, size_t n)
+{
+	for (size_t i = 0; i < n; i++) {
+		if (a[i] != b[i]) {
+			fprintf(stderr, "    byte[%zu]: got 0x%02x, expected 0x%02x\n",
+				i, a[i], b[i]);
+			return 0;
+		}
+	}
+	return 1;
+}
+
+static void __attribute__((optimize("no-tree-loop-distribute-patterns")))
+fill_pattern(uint8_t *buf, size_t n)
+{
+	for (size_t i = 0; i < n; i++)
+		buf[i] = (uint8_t)(i & 0xFF);
+}
+
+static void __attribute__((optimize("no-tree-loop-distribute-patterns")))
+clear_buf(uint8_t *buf, size_t n)
+{
+	for (size_t i = 0; i < n; i++)
+		buf[i] = 0;
+}
+
+/* ---- memset tests ---- */
+
+static int test_memset_correctness(void)
+{
+	uint8_t *buf = alloc_aligned(MAX_SIZE);
+
+	ASSERT_TRUE(buf != NULL);
+
+	for (size_t s = 0; s < NUM_SIZES; s++) {
+		size_t n = test_sizes[s];
+
+		/* Test with 0xAA */
+		clear_buf(buf, n);
+		memset(buf, 0xAA, n);
+		if (!verify_set(buf, 0xAA, n)) {
+			fprintf(stderr, "    memset(0xAA) failed at size %zu\n", n);
+			free(buf);
+			return 1;
+		}
+
+		/* Test with 0x00 */
+		fill_pattern(buf, n);
+		memset(buf, 0x00, n);
+		if (!verify_set(buf, 0x00, n)) {
+			fprintf(stderr, "    memset(0x00) failed at size %zu\n", n);
+			free(buf);
+			return 1;
+		}
+
+		/* Test with 0xFF */
+		clear_buf(buf, n);
+		memset(buf, 0xFF, n);
+		if (!verify_set(buf, 0xFF, n)) {
+			fprintf(stderr, "    memset(0xFF) failed at size %zu\n", n);
+			free(buf);
+			return 1;
+		}
+	}
+
+	free(buf);
+	return 0;
+}
+
+/* ---- memcpy tests ---- */
+
+static int test_memcpy_correctness(void)
+{
+	uint8_t *src = alloc_aligned(MAX_SIZE);
+	uint8_t *dst = alloc_aligned(MAX_SIZE);
+
+	ASSERT_TRUE(src != NULL && dst != NULL);
+
+	fill_pattern(src, MAX_SIZE);
+
+	for (size_t s = 0; s < NUM_SIZES; s++) {
+		size_t n = test_sizes[s];
+
+		clear_buf(dst, n);
+		memcpy(dst, src, n);
+		if (!verify_equal(dst, src, n)) {
+			fprintf(stderr, "    memcpy failed at size %zu\n", n);
+			free(src);
+			free(dst);
+			return 1;
+		}
+	}
+
+	free(src);
+	free(dst);
+	return 0;
+}
+
+/* ---- memmove tests ---- */
+
+static int test_memmove_nonoverlap(void)
+{
+	uint8_t *src = alloc_aligned(MAX_SIZE);
+	uint8_t *dst = alloc_aligned(MAX_SIZE);
+
+	ASSERT_TRUE(src != NULL && dst != NULL);
+
+	fill_pattern(src, MAX_SIZE);
+
+	for (size_t s = 0; s < NUM_SIZES; s++) {
+		size_t n = test_sizes[s];
+
+		clear_buf(dst, n);
+		memmove(dst, src, n);
+		if (!verify_equal(dst, src, n)) {
+			fprintf(stderr, "    memmove (non-overlap) failed at size %zu\n", n);
+			free(src);
+			free(dst);
+			return 1;
+		}
+	}
+
+	free(src);
+	free(dst);
+	return 0;
+}
+
+static int test_memmove_overlap_forward(void)
+{
+	/* Overlapping forward: dst > src, dst within [src, src+n) */
+	size_t buf_size = MAX_SIZE + 4096;
+	uint8_t *buf = alloc_aligned(buf_size);
+	uint8_t *ref = alloc_aligned(buf_size);
+
+	ASSERT_TRUE(buf != NULL && ref != NULL);
+
+	size_t overlap_sizes[] = {128, 1024, 4096, 65536, 131072};
+	int num = sizeof(overlap_sizes) / sizeof(overlap_sizes[0]);
+
+	for (int s = 0; s < num; s++) {
+		size_t n = overlap_sizes[s];
+		size_t offset = n / 4;
+
+		fill_pattern(buf, n + offset);
+		fill_pattern(ref, n + offset);
+
+		/* Reference: manual backward copy (correct for forward overlap) */
+		for (size_t i = n; i > 0; i--)
+			ref[offset + i - 1] = ref[i - 1];
+
+		memmove(buf + offset, buf, n);
+
+		if (!verify_equal(buf + offset, ref + offset, n)) {
+			fprintf(stderr, "    memmove (overlap forward) failed at size %zu\n", n);
+			free(buf);
+			free(ref);
+			return 1;
+		}
+	}
+
+	free(buf);
+	free(ref);
+	return 0;
+}
+
+static int test_memmove_overlap_backward(void)
+{
+	/* Overlapping backward: dst < src, src within [dst, dst+n) */
+	size_t buf_size = MAX_SIZE + 4096;
+	uint8_t *buf = alloc_aligned(buf_size);
+	uint8_t *ref = alloc_aligned(buf_size);
+
+	ASSERT_TRUE(buf != NULL && ref != NULL);
+
+	size_t overlap_sizes[] = {128, 1024, 4096, 65536, 131072};
+	int num = sizeof(overlap_sizes) / sizeof(overlap_sizes[0]);
+
+	for (int s = 0; s < num; s++) {
+		size_t n = overlap_sizes[s];
+		size_t offset = n / 4;
+
+		fill_pattern(buf, n + offset);
+		fill_pattern(ref, n + offset);
+
+		/* Reference: forward copy (correct for backward overlap) */
+		for (size_t i = 0; i < n; i++)
+			ref[i] = ref[offset + i];
+
+		memmove(buf, buf + offset, n);
+
+		if (!verify_equal(buf, ref, n)) {
+			fprintf(stderr, "    memmove (overlap backward) failed at size %zu\n", n);
+			free(buf);
+			free(ref);
+			return 1;
+		}
+	}
+
+	free(buf);
+	free(ref);
+	return 0;
+}
+
+/* ---- memcmp tests ---- */
+
+static int test_memcmp_equal(void)
+{
+	uint8_t *a = alloc_aligned(MAX_SIZE);
+	uint8_t *b = alloc_aligned(MAX_SIZE);
+
+	ASSERT_TRUE(a != NULL && b != NULL);
+
+	fill_pattern(a, MAX_SIZE);
+	fill_pattern(b, MAX_SIZE);
+
+	for (size_t s = 0; s < NUM_SIZES; s++) {
+		size_t n = test_sizes[s];
+
+		if (memcmp(a, b, n) != 0) {
+			fprintf(stderr, "    memcmp(equal) returned non-zero at size %zu\n", n);
+			free(a);
+			free(b);
+			return 1;
+		}
+	}
+
+	free(a);
+	free(b);
+	return 0;
+}
+
+static int test_memcmp_differ(void)
+{
+	uint8_t *a = alloc_aligned(MAX_SIZE);
+	uint8_t *b = alloc_aligned(MAX_SIZE);
+
+	ASSERT_TRUE(a != NULL && b != NULL);
+
+	for (size_t s = 0; s < NUM_SIZES; s++) {
+		size_t n = test_sizes[s];
+
+		if (n == 0)
+			continue;
+
+		fill_pattern(a, n);
+		fill_pattern(b, n);
+
+		/* Make last byte different */
+		b[n - 1] = (uint8_t)(~a[n - 1]);
+
+		int result = memcmp(a, b, n);
+
+		if (result == 0) {
+			fprintf(stderr, "    memcmp returned 0 for different buffers at size %zu\n", n);
+			free(a);
+			free(b);
+			return 1;
+		}
+
+		/* Verify sign matches expectation */
+		int expected_sign = (a[n - 1] > b[n - 1]) ? 1 : -1;
+		int actual_sign = (result > 0) ? 1 : -1;
+
+		if (actual_sign != expected_sign) {
+			fprintf(stderr, "    memcmp sign mismatch at size %zu: got %d, expected %d\n",
+				n, actual_sign, expected_sign);
+			free(a);
+			free(b);
+			return 1;
+		}
+	}
+
+	free(a);
+	free(b);
+	return 0;
+}
+
+/* ---- Edge case tests ---- */
+
+static int test_zero_length(void)
+{
+	uint8_t a[16], b[16], save_a[16];
+
+	fill_pattern(a, 16);
+	clear_buf(b, 16);
+
+	/* Save original a */
+	for (int i = 0; i < 16; i++)
+		save_a[i] = a[i];
+
+	/* memset with n=0 should not modify buffer */
+	memset(a, 0xFF, 0);
+	ASSERT_TRUE(verify_equal(a, save_a, 16));
+
+	/* memcpy with n=0 should not modify dst */
+	memcpy(b, a, 0);
+	ASSERT_TRUE(verify_set(b, 0, 16));
+
+	/* memmove with n=0 should not modify dst */
+	memmove(b, a, 0);
+	ASSERT_TRUE(verify_set(b, 0, 16));
+
+	/* memcmp with n=0 should return 0 */
+	ASSERT_EQ(memcmp(a, b, 0), 0);
+
+	return 0;
+}
+
+static int test_memcpy_unaligned(void)
+{
+	size_t buf_size = MAX_SIZE + 64;
+	uint8_t *src_base = alloc_aligned(buf_size);
+	uint8_t *dst_base = alloc_aligned(buf_size);
+
+	ASSERT_TRUE(src_base != NULL && dst_base != NULL);
+
+	int offsets[] = {1, 3, 7, 13, 31, 63};
+	int num_offsets = sizeof(offsets) / sizeof(offsets[0]);
+	size_t sizes[] = {64, 1024, 4096, 65536, 131072};
+	int num_sizes = sizeof(sizes) / sizeof(sizes[0]);
+
+	for (int o = 0; o < num_offsets; o++) {
+		uint8_t *src = src_base + offsets[o];
+		uint8_t *dst = dst_base + offsets[o];
+
+		fill_pattern(src, MAX_SIZE);
+
+		for (int s = 0; s < num_sizes; s++) {
+			size_t n = sizes[s];
+
+			clear_buf(dst, n);
+			memcpy(dst, src, n);
+
+			if (!verify_equal(dst, src, n)) {
+				fprintf(stderr, "    memcpy (unaligned offset=%d) failed at size %zu\n",
+					offsets[o], n);
+				free(src_base);
+				free(dst_base);
+				return 1;
+			}
+		}
+	}
+
+	free(src_base);
+	free(dst_base);
+	return 0;
+}
+
+/* ---- Multithreaded correctness test ---- */
+
+#define MT_NUM_THREADS 4
+#define MT_BUF_SIZE (128 * 1024)
+#define MT_ITERS 100
+
+struct mt_result {
+	int passed;
+	int thread_id;
+};
+
+static void *mt_worker(void *arg)
+{
+	struct mt_result *result = (struct mt_result *)arg;
+	uint8_t *src = alloc_aligned(MT_BUF_SIZE);
+	uint8_t *dst = alloc_aligned(MT_BUF_SIZE);
+
+	result->passed = 1;
+
+	if (!src || !dst) {
+		result->passed = 0;
+		free(src);
+		free(dst);
+		return NULL;
+	}
+
+	for (int i = 0; i < MT_ITERS; i++) {
+		uint8_t pattern = (uint8_t)(i & 0xFF);
+
+		memset(src, pattern, MT_BUF_SIZE);
+		if (!verify_set(src, pattern, MT_BUF_SIZE)) {
+			fprintf(stderr, "    thread %d: memset failed at iter %d\n",
+				result->thread_id, i);
+			result->passed = 0;
+			break;
+		}
+
+		memcpy(dst, src, MT_BUF_SIZE);
+		if (!verify_equal(dst, src, MT_BUF_SIZE)) {
+			fprintf(stderr, "    thread %d: memcpy failed at iter %d\n",
+				result->thread_id, i);
+			result->passed = 0;
+			break;
+		}
+	}
+
+	free(src);
+	free(dst);
+	return NULL;
+}
+
+static int test_multithread(void)
+{
+	pthread_t threads[MT_NUM_THREADS];
+	struct mt_result results[MT_NUM_THREADS];
+
+	for (int i = 0; i < MT_NUM_THREADS; i++) {
+		results[i].thread_id = i;
+		pthread_create(&threads[i], NULL, mt_worker, &results[i]);
+	}
+
+	for (int i = 0; i < MT_NUM_THREADS; i++)
+		pthread_join(threads[i], NULL);
+
+	for (int i = 0; i < MT_NUM_THREADS; i++) {
+		if (!results[i].passed) {
+			fprintf(stderr, "    Thread %d failed\n", i);
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+/* ---- Test runner ---- */
+
+int main(void)
+{
+	printf("DTO Functional Tests\n");
+	printf("====================\n\n");
+
+	struct dto_test tests[] = {
+		TEST_ENTRY(test_memset_correctness),
+		TEST_ENTRY(test_memcpy_correctness),
+		TEST_ENTRY(test_memmove_nonoverlap),
+		TEST_ENTRY(test_memmove_overlap_forward),
+		TEST_ENTRY(test_memmove_overlap_backward),
+		TEST_ENTRY(test_memcmp_equal),
+		TEST_ENTRY(test_memcmp_differ),
+		TEST_ENTRY(test_zero_length),
+		TEST_ENTRY(test_memcpy_unaligned),
+		TEST_ENTRY(test_multithread),
+		{NULL, NULL}
+	};
+
+	return run_tests(tests);
+}

--- a/tests/test_perf.c
+++ b/tests/test_perf.c
@@ -1,0 +1,1215 @@
+/*******************************************************************************
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * test_perf.c - Statically-linked A/B performance comparison.
+ *
+ * Both the baseline and current versions of libdto are compiled into this
+ * binary as object files with renamed symbols:
+ *   - Baseline: bl_memcpy, bl_memset, bl_memcmp, bl_memmove
+ *   - Current:  cur_memcpy, cur_memset, cur_memcmp, cur_memmove
+ *
+ * For each benchmark size, tests all DTO configs (stdc, dsa, dsa_auto)
+ * with both 4KB and 2MB page sizes, running interleaved A/B comparisons
+ * in forked children.
+ *
+ * Environment variables:
+ *   PERF_MIN_EFFECT   - Minimum trimmed mean change %% to FAIL (default: 2)
+ *   PERF_AB_ROUNDS    - Number of interleaved A/B rounds (default: 3)
+ *   PERF_SHORT        - 1 = fast sanity subset: memcpy 4k/64k/1m + memset
+ *                       64k, 100 iterations, 1 round, 5%% threshold
+ *   PERF_ITERS        - Iterations per A/B round (default: 10000)
+ *   RESULTS_DIR       - Directory to write sample + CSV files
+ *   PERF_CPU          - CPU core to pin to (default: 1)
+ *   PERF_COLD_CACHE   - 1=flush per iteration (default), 0=flush once
+ *   PERF_CORE_FREQ_MHZ   - Pin core frequency (MHz); 0/unset leaves it alone
+ *   PERF_UNCORE_FREQ_MHZ - Pin uncore frequency (MHz); 0/unset leaves it alone
+ *   PERF_OP           - Run only this op type: memcpy, memset, or memcmp
+ *   PERF_SIZE         - Run only this size (e.g. 4k, 64k, 128k, 1m)
+ ******************************************************************************/
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "dto_test_utils.h"
+
+#include <stdint.h>
+#include <sched.h>
+#include <dlfcn.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <math.h>
+#include <errno.h>
+#include <signal.h>
+#include <x86intrin.h>
+
+/* ---- Extern declarations for statically-linked DTO versions ---- */
+
+extern void *bl_memcpy(void *dest, const void *src, size_t n);
+extern void *bl_memset(void *s, int c, size_t n);
+extern int   bl_memcmp(const void *s1, const void *s2, size_t n);
+
+extern void *cur_memcpy(void *dest, const void *src, size_t n);
+extern void *cur_memset(void *s, int c, size_t n);
+extern int   cur_memcmp(const void *s1, const void *s2, size_t n);
+
+/* ---- Configuration ---- */
+
+#define WARMUP_ITERS  100
+#define DEFAULT_CPU   1
+
+static int cold_cache;
+static double tsc_ghz;
+static int short_mode;
+static int filter_op = -1;
+static size_t filter_size;
+
+/* ---- rdtsc helpers ---- */
+
+static inline uint64_t rdtsc_start(void)
+{
+	__asm__ volatile("lfence");
+	return __rdtsc();
+}
+
+static inline uint64_t rdtsc_end(void)
+{
+	unsigned int aux;
+
+	return __rdtscp(&aux);
+}
+
+static double calibrate_tsc(void)
+{
+	struct timespec t0, t1;
+	uint64_t tsc0, tsc1, elapsed_ns;
+
+	clock_gettime(CLOCK_MONOTONIC, &t0);
+	tsc0 = rdtsc_end();
+	do {
+		clock_gettime(CLOCK_MONOTONIC, &t1);
+		elapsed_ns = (t1.tv_sec - t0.tv_sec) * 1000000000ULL +
+			     (t1.tv_nsec - t0.tv_nsec);
+	} while (elapsed_ns < 50000000ULL);
+	tsc1 = rdtsc_end();
+	return (double)(tsc1 - tsc0) / (double)elapsed_ns;
+}
+
+/* ---- CPU pinning ---- */
+
+static int pin_to_cpu(int cpu)
+{
+	cpu_set_t mask;
+
+	CPU_ZERO(&mask);
+	CPU_SET(cpu, &mask);
+	if (sched_setaffinity(0, sizeof(mask), &mask) < 0) {
+		perror("sched_setaffinity");
+		return -1;
+	}
+	return 0;
+}
+
+/* ---- Frequency pinning ---- */
+
+static struct {
+	int active;
+	int core_pinned;
+	int cpu;
+	unsigned long orig_core_min_khz, orig_core_max_khz;
+	char uncore_dir[256];
+	unsigned long orig_uncore_min_khz, orig_uncore_max_khz;
+} freq_state;
+
+static int read_sysfs_ulong(const char *path, unsigned long *val)
+{
+	FILE *f = fopen(path, "r");
+
+	if (!f) return -1;
+	if (fscanf(f, "%lu", val) != 1) { fclose(f); return -1; }
+	fclose(f);
+	return 0;
+}
+
+static int write_sysfs_ulong(const char *path, unsigned long val)
+{
+	FILE *f = fopen(path, "w");
+
+	if (!f) return -1;
+	fprintf(f, "%lu", val);
+	fclose(f);
+	return 0;
+}
+
+static int set_core_freq(int cpu, unsigned long khz)
+{
+	char path[256];
+	unsigned long abs_min;
+
+	snprintf(path, sizeof(path),
+		 "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_min_freq", cpu);
+	if (read_sysfs_ulong(path, &abs_min) < 0) return -1;
+	snprintf(path, sizeof(path),
+		 "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_min_freq", cpu);
+	if (write_sysfs_ulong(path, abs_min) < 0) return -1;
+	snprintf(path, sizeof(path),
+		 "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_max_freq", cpu);
+	if (write_sysfs_ulong(path, khz) < 0) return -1;
+	snprintf(path, sizeof(path),
+		 "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_min_freq", cpu);
+	return write_sysfs_ulong(path, khz);
+}
+
+static void restore_freq(void)
+{
+	char path[512];
+
+	if (!freq_state.active) return;
+	freq_state.active = 0;
+	if (freq_state.core_pinned) {
+		set_core_freq(freq_state.cpu, freq_state.orig_core_max_khz);
+		snprintf(path, sizeof(path),
+			 "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_min_freq",
+			 freq_state.cpu);
+		write_sysfs_ulong(path, freq_state.orig_core_min_khz);
+	}
+
+	if (freq_state.uncore_dir[0]) {
+		snprintf(path, sizeof(path), "%s/min_freq_khz",
+			 freq_state.uncore_dir);
+		write_sysfs_ulong(path, freq_state.orig_uncore_min_khz);
+		snprintf(path, sizeof(path), "%s/max_freq_khz",
+			 freq_state.uncore_dir);
+		write_sysfs_ulong(path, freq_state.orig_uncore_max_khz);
+	}
+}
+
+static void restore_freq_and_die(int sig)
+{
+	restore_freq();
+	signal(sig, SIG_DFL);
+	raise(sig);
+}
+
+/*
+ * Pin core and/or uncore frequency. A value of 0 for either core_mhz or
+ * uncore_mhz leaves that domain untouched, so the two can be controlled
+ * independently.
+ */
+static int pin_freq(int cpu, unsigned long core_mhz, unsigned long uncore_mhz)
+{
+	char path[512];
+	/* atexit does not run when the process dies by signal (^C, ctest
+	 * timeout kill); restore the frequency there too before dying. */
+	static const int fatal_sigs[] = { SIGINT, SIGTERM, SIGHUP, SIGQUIT };
+
+	freq_state.cpu = cpu;
+	freq_state.active = 1;
+	atexit(restore_freq);
+	for (size_t i = 0; i < sizeof(fatal_sigs) / sizeof(fatal_sigs[0]); i++)
+		signal(fatal_sigs[i], restore_freq_and_die);
+
+	/* Pin core */
+	if (core_mhz) {
+		unsigned long core_khz = core_mhz * 1000;
+
+		snprintf(path, sizeof(path),
+			 "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_min_freq", cpu);
+		if (read_sysfs_ulong(path, &freq_state.orig_core_min_khz) < 0) {
+			fprintf(stderr, "ERROR: cannot read core freq for CPU %d\n", cpu);
+			return -1;
+		}
+		snprintf(path, sizeof(path),
+			 "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_max_freq", cpu);
+		read_sysfs_ulong(path, &freq_state.orig_core_max_khz);
+		if (set_core_freq(cpu, core_khz) < 0) {
+			fprintf(stderr, "ERROR: could not pin core freq to %lu MHz\n",
+				core_mhz);
+			return -1;
+		}
+		freq_state.core_pinned = 1;
+	}
+
+	/* Pin uncore */
+	if (!uncore_mhz)
+		return 0;
+
+	unsigned long uncore_khz = uncore_mhz * 1000;
+	unsigned long pkg = 0, die = 0;
+
+	snprintf(path, sizeof(path),
+		 "/sys/devices/system/cpu/cpu%d/topology/physical_package_id", cpu);
+	read_sysfs_ulong(path, &pkg);
+	snprintf(path, sizeof(path),
+		 "/sys/devices/system/cpu/cpu%d/topology/die_id", cpu);
+	if (read_sysfs_ulong(path, &die) < 0) die = 0;
+
+	snprintf(freq_state.uncore_dir, sizeof(freq_state.uncore_dir),
+		 "/sys/devices/system/cpu/intel_uncore_frequency/"
+		 "package_%02lu_die_%02lu", pkg, die);
+
+	snprintf(path, sizeof(path), "%s/min_freq_khz", freq_state.uncore_dir);
+	if (read_sysfs_ulong(path, &freq_state.orig_uncore_min_khz) == 0) {
+		snprintf(path, sizeof(path), "%s/max_freq_khz",
+			 freq_state.uncore_dir);
+		read_sysfs_ulong(path, &freq_state.orig_uncore_max_khz);
+
+		snprintf(path, sizeof(path), "%s/min_freq_khz",
+			 freq_state.uncore_dir);
+		write_sysfs_ulong(path, freq_state.orig_uncore_min_khz);
+		snprintf(path, sizeof(path), "%s/max_freq_khz",
+			 freq_state.uncore_dir);
+		if (write_sysfs_ulong(path, uncore_khz) < 0) {
+			fprintf(stderr, "WARNING: could not pin uncore freq\n");
+			freq_state.uncore_dir[0] = '\0';
+		} else {
+			snprintf(path, sizeof(path), "%s/min_freq_khz",
+				 freq_state.uncore_dir);
+			write_sysfs_ulong(path, uncore_khz);
+		}
+	} else {
+		fprintf(stderr, "WARNING: uncore sysfs not found\n");
+		freq_state.uncore_dir[0] = '\0';
+	}
+
+	return 0;
+}
+
+static void print_freq_info(int cpu)
+{
+	char path[512];
+	unsigned long cur_freq, min_freq, max_freq;
+
+	snprintf(path, sizeof(path),
+		 "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", cpu);
+	if (read_sysfs_ulong(path, &cur_freq) == 0) {
+		snprintf(path, sizeof(path),
+			 "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_min_freq", cpu);
+		read_sysfs_ulong(path, &min_freq);
+		snprintf(path, sizeof(path),
+			 "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_max_freq", cpu);
+		read_sysfs_ulong(path, &max_freq);
+		printf("Core freq:     %lu MHz (min=%lu max=%lu)%s\n",
+		       cur_freq / 1000, min_freq / 1000, max_freq / 1000,
+		       (min_freq == max_freq) ? " [pinned]" : "");
+	}
+	if (freq_state.uncore_dir[0]) {
+		snprintf(path, sizeof(path), "%s/min_freq_khz",
+			 freq_state.uncore_dir);
+		if (read_sysfs_ulong(path, &min_freq) == 0) {
+			snprintf(path, sizeof(path), "%s/max_freq_khz",
+				 freq_state.uncore_dir);
+			read_sysfs_ulong(path, &max_freq);
+			printf("Uncore freq:   min=%lu max=%lu MHz%s\n",
+			       min_freq / 1000, max_freq / 1000,
+			       (min_freq == max_freq) ? " [pinned]" : "");
+		}
+	}
+}
+
+/* ---- Cache flush ---- */
+
+static inline void clflushopt_addr(volatile void *p)
+{
+	asm volatile("clflushopt (%0)" :: "r"(p) : "memory");
+}
+
+static void flush_buffer(void *buf, size_t size)
+{
+	char *p = buf;
+
+	for (size_t i = 0; i < size; i += 64)
+		clflushopt_addr(p + i);
+	_mm_sfence();
+}
+
+/* ---- Benchmark definitions ---- */
+
+enum perf_op { OP_MEMSET, OP_MEMCPY, OP_MEMCMP };
+
+struct perf_test {
+	const char *name;
+	enum perf_op op;
+	size_t size;
+	int ref_only;
+	int pf_pct;	/* page-fault probability: 0=none, 1=1%, etc. */
+};
+
+static struct perf_test benchmarks[] = {
+	{"memcpy_4k",      OP_MEMCPY, 4096,    1, 0},
+	{"memcpy_8k",      OP_MEMCPY, 8192,    1, 0},
+	{"memcpy_16k",     OP_MEMCPY, 16384,   0, 0},
+	{"memcpy_32k",     OP_MEMCPY, 32768,   0, 0},
+	{"memcpy_64k",     OP_MEMCPY, 65536,   0, 0},
+	{"memcpy_128k",    OP_MEMCPY, 131072,  0, 0},
+	{"memcpy_256k",    OP_MEMCPY, 262144,  0, 0},
+	{"memcpy_512k",    OP_MEMCPY, 524288,  0, 0},
+	{"memcpy_1m",      OP_MEMCPY, 1048576, 0, 0},
+	{"memcpy_1m_pf50",  OP_MEMCPY, 1048576, 0, 50},
+	{"memset_64k",     OP_MEMSET, 65536,   0, 0},
+	{"memset_128k",    OP_MEMSET, 131072,  0, 0},
+	{"memset_256k",    OP_MEMSET, 262144,  0, 0},
+	{"memset_1m",      OP_MEMSET, 1048576, 0, 0},
+	{"memcmp_64k",     OP_MEMCMP, 65536,   0, 0},
+	{"memcmp_128k",    OP_MEMCMP, 131072,  0, 0},
+	{"memcmp_1m",      OP_MEMCMP, 1048576, 0, 0},
+	{NULL, 0, 0, 0, 0}
+};
+
+#define DEFAULT_ITERS  10000
+
+/* ---- DTO config sets ---- */
+
+struct dto_config {
+	const char *label;
+	int use_libc;	/* 1 = bypass DTO, use raw libc via dlsym */
+	struct { const char *key; const char *val; } envs[8];
+};
+
+static struct dto_config dto_configs[] = {
+	{"cpu",      1, {{NULL, NULL}}},
+	{"stdc",     0, {{"DTO_USESTDC_CALLS", "1"}, {NULL, NULL}}},
+	{"dsa",      0, {{"DTO_CPU_SIZE_FRACTION", "0"},
+			  {"DTO_AUTO_ADJUST_KNOBS", "0"},
+			  {"DTO_MIN_BYTES", "4096"}, {NULL, NULL}}},
+	{"dsa_auto", 0, {{"DTO_CPU_SIZE_FRACTION", "0"},
+			  {"DTO_AUTO_ADJUST_KNOBS", "1"},
+			  {"DTO_MIN_BYTES", "4096"}, {NULL, NULL}}},
+};
+#define NUM_DTO_CONFIGS (sizeof(dto_configs) / sizeof(dto_configs[0]))
+#define CPU_CONFIG_IDX 0
+
+/* Page size configs */
+struct page_config {
+	const char *label;
+	int hugepage;
+};
+
+static struct page_config page_configs[] = {
+	{"4k",  0},
+	{"2m",  1},
+};
+#define NUM_PAGE_CONFIGS (sizeof(page_configs) / sizeof(page_configs[0]))
+
+/*
+ * Benchmark selection: PERF_OP/PERF_SIZE filters, plus the PERF_SHORT
+ * sanity subset — memcpy 4k/64k/1m and memset 64k, no fault-injection
+ * variants. Used by the run loop and both output passes so skipped
+ * benchmarks disappear from the tables instead of printing as errors.
+ */
+static int test_selected(const struct perf_test *test)
+{
+	if (filter_op >= 0 && (int)test->op != filter_op)
+		return 0;
+	if (filter_size && test->size != filter_size)
+		return 0;
+	if (short_mode &&
+	    !((test->op == OP_MEMCPY && test->pf_pct == 0 &&
+	       (test->size == 4096 || test->size == 65536 ||
+		test->size == 1048576)) ||
+	      (test->op == OP_MEMSET && test->size == 65536)))
+		return 0;
+	return 1;
+}
+
+/* ---- Shared memory for child results ---- */
+
+struct shared_result {
+	int ok;
+	int nsamples;
+	int requested_iters;  /* parent sets this before fork */
+	int pad;              /* keep the uint64_t sample arrays at (slot + 1)
+			       * 8-byte aligned */
+};
+
+#define MAX_CHILD_SAMPLES DEFAULT_ITERS
+#define SHARED_SLOT_SIZE (sizeof(struct shared_result) + \
+			  2 * MAX_CHILD_SAMPLES * sizeof(uint64_t))
+
+static uint64_t *get_bl_samples(struct shared_result *slot)
+{
+	return (uint64_t *)(slot + 1);
+}
+
+static uint64_t *get_cur_samples(struct shared_result *slot)
+{
+	return (uint64_t *)(slot + 1) + MAX_CHILD_SAMPLES;
+}
+
+/* ---- Buffer allocation ---- */
+
+static size_t buf_alloc_size(size_t size, int hugepage)
+{
+	if (hugepage)
+		return (size + (2 << 20) - 1) & ~((2 << 20) - 1UL);
+	return size;
+}
+
+static void *alloc_shared_buffer(size_t size, int hugepage)
+{
+	int flags = MAP_SHARED | MAP_ANONYMOUS | MAP_POPULATE;
+	size_t alloc = buf_alloc_size(size, hugepage);
+
+	if (hugepage)
+		flags |= MAP_HUGETLB | (21 << MAP_HUGE_SHIFT);
+
+	void *p = mmap(NULL, alloc, PROT_READ | PROT_WRITE, flags, -1, 0);
+
+	return (p == MAP_FAILED) ? NULL : p;
+}
+
+static void free_shared_buffer(void *p, size_t size, int hugepage)
+{
+	munmap(p, buf_alloc_size(size, hugepage));
+}
+
+/* ---- Sort ---- */
+
+static int cmp_u64(const void *a, const void *b)
+{
+	uint64_t va = *(const uint64_t *)a;
+	uint64_t vb = *(const uint64_t *)b;
+
+	return (va > vb) - (va < vb);
+}
+
+static volatile int benchmark_sink;
+
+/* Iterations per A/B round; PERF_ITERS (capped at DEFAULT_ITERS, which
+ * sizes the shared result slot) or PERF_SHORT override the default. */
+static int perf_iters = DEFAULT_ITERS;
+
+/* ---- KS test ---- */
+
+struct ks_result {
+	double d;
+	double p;
+};
+
+static struct ks_result ks_test(const uint64_t *a, int n1,
+				const uint64_t *b, int n2)
+{
+	struct ks_result r = {0.0, 1.0};
+	int i = 0, j = 0;
+	double d_max = 0.0;
+
+	while (i < n1 || j < n2) {
+		uint64_t val;
+		double diff;
+
+		if (i < n1 && (j >= n2 || a[i] <= b[j]))
+			val = a[i];
+		else
+			val = b[j];
+
+		while (i < n1 && a[i] == val) i++;
+		while (j < n2 && b[j] == val) j++;
+
+		diff = fabs((double)i / n1 - (double)j / n2);
+		if (diff > d_max)
+			d_max = diff;
+	}
+
+	r.d = d_max;
+
+	double ne = (double)n1 * n2 / (n1 + n2);
+	double lambda = (sqrt(ne) + 0.12 + 0.11 / sqrt(ne)) * d_max;
+	double sum = 0.0;
+
+	for (int k = 1; k <= 100; k++) {
+		double term = exp(-2.0 * k * k * lambda * lambda);
+
+		if (k % 2 == 1)
+			sum += term;
+		else
+			sum -= term;
+		if (term < 1e-12)
+			break;
+	}
+	r.p = 2.0 * sum;
+	if (r.p < 0) r.p = 0;
+	if (r.p > 1) r.p = 1;
+
+	return r;
+}
+
+/* ---- CSV export ---- */
+
+static void append_csv(const char *dir, const char *testname,
+		       const char *config, const char *pagesz,
+		       const char *version,
+		       const uint64_t *ticks, int count, double ghz)
+{
+	char path[4096];
+	FILE *f;
+	int need_header;
+
+	snprintf(path, sizeof(path), "%s/distributions.csv", dir);
+	f = fopen(path, "r");
+	need_header = (f == NULL);
+	if (f) fclose(f);
+
+	f = fopen(path, "a");
+	if (!f) return;
+
+	if (need_header)
+		fprintf(f, "test,config,pagesize,version,latency_ns\n");
+
+	for (int i = 0; i < count; i++)
+		fprintf(f, "%s,%s,%s,%s,%.1f\n",
+			testname, config, pagesz, version,
+			(double)ticks[i] / ghz);
+	fclose(f);
+}
+
+/* ---- Result for one (config, pagesize) cell in the table ---- */
+
+struct cell_result {
+	int valid;
+	int skipped;	/* environment can't run this cell (no hugepages) */
+	int iters;	/* iterations per round (from pilot) */
+	int n_total;	/* total samples (rounds × iters) */
+	int bl_outliers;/* baseline outliers (outside trimmed range) */
+	int cur_outliers;
+	double bl_ns;	/* baseline trimmed mean (10th-90th pctl) */
+	double cur_ns;	/* current trimmed mean */
+	double change;	/* percent change */
+	double ks_d;
+	double ks_p;
+	int regression;
+	int improved;
+};
+
+/* ---- Function pointer types for cpu/libc mode ---- */
+
+typedef void *(*fn_memcpy_t)(void *, const void *, size_t);
+typedef void *(*fn_memset_t)(void *, int, size_t);
+typedef int   (*fn_memcmp_t)(const void *, const void *, size_t);
+
+/* ---- Child: interleaved A/B benchmark ---- */
+
+/*
+ * Drop one page so the next access to it faults. Warns once (per child) if
+ * MADV_DONTNEED is rejected — e.g. hugetlb MADV_DONTNEED is unsupported before
+ * Linux ~5.18 — so a silently fault-free _pf run is visible rather than
+ * masquerading as page-fault-path numbers.
+ */
+static void pf_drop_page(void *addr, size_t len)
+{
+	static int warned;
+
+	if (madvise(addr, len, MADV_DONTNEED) != 0 && !warned) {
+		warned = 1;
+		fprintf(stderr,
+			"WARNING: MADV_DONTNEED failed (%s); page-fault injection "
+			"is not being applied on this kernel/configuration\n",
+			strerror(errno));
+	}
+}
+
+static void child_run_ab(struct perf_test *test,
+			 struct shared_result *slot,
+			 uint8_t *src, uint8_t *dst,
+			 int use_libc, int hugepage)
+{
+	uint64_t *bl_s = get_bl_samples(slot);
+	uint64_t *cur_s = get_cur_samples(slot);
+	uint64_t start, end;
+	int iters = slot->requested_iters;
+
+	/*
+	 * Function pointers: for cpu mode, resolve libc directly.
+	 * For DTO modes, use the statically-linked bl_/cur_ symbols.
+	 */
+	fn_memcpy_t a_memcpy, b_memcpy;
+	fn_memset_t a_memset, b_memset;
+	fn_memcmp_t a_memcmp, b_memcmp;
+
+	if (use_libc) {
+		void *libc = dlopen("libc.so.6", RTLD_NOW | RTLD_NOLOAD);
+
+		if (!libc) libc = dlopen("libc.so.6", RTLD_NOW);
+		if (!libc) _exit(1);
+		a_memcpy = b_memcpy = (fn_memcpy_t)dlsym(libc, "memcpy");
+		a_memset = b_memset = (fn_memset_t)dlsym(libc, "memset");
+		a_memcmp = b_memcmp = (fn_memcmp_t)dlsym(libc, "memcmp");
+		if (!a_memcpy || !a_memset || !a_memcmp) _exit(1);
+	} else {
+		a_memcpy = (fn_memcpy_t)bl_memcpy;
+		b_memcpy = (fn_memcpy_t)cur_memcpy;
+		a_memset = (fn_memset_t)bl_memset;
+		b_memset = (fn_memset_t)cur_memset;
+		a_memcmp = bl_memcmp;
+		b_memcmp = cur_memcmp;
+	}
+
+	if (iters < 1) iters = 1;
+	if (iters > MAX_CHILD_SAMPLES)
+		iters = MAX_CHILD_SAMPLES;
+
+	for (size_t i = 0; i < test->size; i++) {
+		src[i] = (uint8_t)(i & 0xFF);
+		dst[i] = (uint8_t)(i & 0xFF);
+        }
+
+	/* Quick warmup phase */
+	for (int w = 0; w < WARMUP_ITERS; w++) {
+		switch (test->op) {
+		case OP_MEMSET: a_memset(dst, 0xAA, test->size);
+				b_memset(dst, 0xAA, test->size); break;
+		case OP_MEMCPY: a_memcpy(dst, src, test->size);
+				b_memcpy(dst, src, test->size); break;
+		case OP_MEMCMP: benchmark_sink = a_memcmp(dst, src, test->size);
+				benchmark_sink = b_memcmp(dst, src, test->size); break;
+		}
+	}
+
+	/*
+	 * Page fault injection setup. Use the mapping's actual page size:
+	 * MADV_DONTNEED on a MAP_HUGETLB region must be huge-page aligned and
+	 * sized, so a 4KB range would fail with EINVAL and inject nothing.
+	 * num_pages is derived from the rounded-up allocation size so a buffer
+	 * smaller than one huge page still yields one droppable page.
+	 */
+	size_t page_size = hugepage ? (2UL << 20) : (size_t)sysconf(_SC_PAGESIZE);
+	size_t num_pages = buf_alloc_size(test->size, hugepage) / page_size;
+	uintptr_t dst_base = (uintptr_t)dst & ~(page_size - 1);
+
+	/* Randomized interleaved measurement */
+	uint32_t rng = (uint32_t)rdtsc_end() | 1;  /* must be nonzero for xorshift */
+
+	for (int i = 0; i < iters; i++) {
+		uint64_t t_bl, t_cur;
+
+		rng ^= rng << 13; rng ^= rng >> 17; rng ^= rng << 5;
+		int bl_first = (rng & 1);
+
+		/* First */
+		if (cold_cache) {
+			flush_buffer(src, test->size);
+			flush_buffer(dst, test->size);
+		}
+		if (test->pf_pct && num_pages > 0) {
+			rng ^= rng << 13; rng ^= rng >> 17; rng ^= rng << 5;
+			if ((rng % 100) < (uint32_t)test->pf_pct) {
+				rng ^= rng << 13; rng ^= rng >> 17; rng ^= rng << 5;
+				size_t pg = rng % num_pages;
+				pf_drop_page((void *)(dst_base + pg * page_size),
+					     page_size);
+			}
+		}
+		start = rdtsc_start();
+		switch (test->op) {
+		case OP_MEMSET: (bl_first ? a_memset : b_memset)(dst, 0xAA, test->size); break;
+		case OP_MEMCPY: (bl_first ? a_memcpy : b_memcpy)(dst, src, test->size); break;
+		case OP_MEMCMP: benchmark_sink = (bl_first ? a_memcmp : b_memcmp)(dst, src, test->size); break;
+		}
+		COMPILER_BARRIER();
+		end = rdtsc_end();
+		if (bl_first) t_bl = end - start; else t_cur = end - start;
+
+		if (test->op == OP_MEMCMP)
+			for (size_t j = 0; j < test->size; j++)
+				dst[j] = src[j];
+
+		/* Second */
+		if (cold_cache) {
+			flush_buffer(src, test->size);
+			flush_buffer(dst, test->size);
+		}
+		if (test->pf_pct && num_pages > 0) {
+			rng ^= rng << 13; rng ^= rng >> 17; rng ^= rng << 5;
+			if ((rng % 100) < (uint32_t)test->pf_pct) {
+				rng ^= rng << 13; rng ^= rng >> 17; rng ^= rng << 5;
+				size_t pg = rng % num_pages;
+				pf_drop_page((void *)(dst_base + pg * page_size),
+					     page_size);
+			}
+		}
+		start = rdtsc_start();
+		switch (test->op) {
+		case OP_MEMSET: (!bl_first ? a_memset : b_memset)(dst, 0xAA, test->size); break;
+		case OP_MEMCPY: (!bl_first ? a_memcpy : b_memcpy)(dst, src, test->size); break;
+		case OP_MEMCMP: benchmark_sink = (!bl_first ? a_memcmp : b_memcmp)(dst, src, test->size); break;
+		}
+		COMPILER_BARRIER();
+		end = rdtsc_end();
+		if (!bl_first) t_bl = end - start; else t_cur = end - start;
+
+		bl_s[i] = t_bl;
+		cur_s[i] = t_cur;
+
+		if (test->op == OP_MEMCMP)
+			for (size_t j = 0; j < test->size; j++)
+				dst[j] = src[j];
+	}
+
+	qsort(bl_s, iters, sizeof(uint64_t), cmp_u64);
+	qsort(cur_s, iters, sizeof(uint64_t), cmp_u64);
+	slot->nsamples = iters;
+	slot->ok = 1;
+	_exit(0);
+}
+
+static int fork_ab(struct perf_test *test, struct shared_result *slot,
+		   uint8_t *src, uint8_t *dst, struct dto_config *cfg,
+		   int iters, int hugepage)
+{
+	pid_t pid;
+	int status;
+
+	slot->ok = 0;
+	slot->requested_iters = iters;
+
+	for (int e = 0; cfg->envs[e].key; e++)
+		setenv(cfg->envs[e].key, cfg->envs[e].val, 1);
+
+	pid = fork();
+	if (pid < 0) { perror("fork"); return -1; }
+
+	if (pid == 0)
+		child_run_ab(test, slot, src, dst, cfg->use_libc, hugepage);
+
+	waitpid(pid, &status, 0);
+
+	for (int e = 0; cfg->envs[e].key; e++)
+		unsetenv(cfg->envs[e].key);
+
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+		return -1;
+	return slot->ok ? 0 : -1;
+}
+
+static struct cell_result run_cell(struct perf_test *test,
+				   struct dto_config *cfg,
+				   struct page_config *pg,
+				   void *shm, int ab_rounds,
+				   double min_effect,
+				   const char *results_dir)
+{
+	struct cell_result res = {0};
+	int iters;
+	int max_total;
+	uint64_t *all_bl, *all_cur;
+	int n_bl = 0, n_cur = 0;
+
+	iters = perf_iters;
+	max_total = ab_rounds * iters;
+
+	uint8_t *src = alloc_shared_buffer(test->size, pg->hugepage);
+	uint8_t *dst = alloc_shared_buffer(test->size, pg->hugepage);
+
+	if (!src || !dst) {
+		if (src) free_shared_buffer(src, test->size, pg->hugepage);
+		if (dst) free_shared_buffer(dst, test->size, pg->hugepage);
+		/* A failed 2MB allocation means no hugepages are reserved on
+		 * this host — an environment limitation, not a regression, so
+		 * skip the cell instead of failing the run. */
+		res.skipped = pg->hugepage;
+		return res;
+	}
+
+	all_bl = malloc(max_total * sizeof(uint64_t));
+	all_cur = malloc(max_total * sizeof(uint64_t));
+	if (!all_bl || !all_cur) {
+		free(all_bl); free(all_cur);
+		free_shared_buffer(src, test->size, pg->hugepage);
+		free_shared_buffer(dst, test->size, pg->hugepage);
+		return res;
+	}
+
+	for (int r = 0; r < ab_rounds; r++) {
+		struct shared_result *slot = shm;
+
+		memset(slot, 0, SHARED_SLOT_SIZE);
+		if (fork_ab(test, slot, src, dst, cfg, iters, pg->hugepage) < 0)
+			goto out;
+
+		memcpy(all_bl + n_bl, get_bl_samples(slot),
+		       slot->nsamples * sizeof(uint64_t));
+		n_bl += slot->nsamples;
+		memcpy(all_cur + n_cur, get_cur_samples(slot),
+		       slot->nsamples * sizeof(uint64_t));
+		n_cur += slot->nsamples;
+	}
+
+	qsort(all_bl, n_bl, sizeof(uint64_t), cmp_u64);
+	qsort(all_cur, n_cur, sizeof(uint64_t), cmp_u64);
+
+	/* Trimmed mean 10th-90th */
+	{
+		int blo = n_bl / 10, bhi = n_bl * 9 / 10;
+		int clo = n_cur / 10, chi = n_cur * 9 / 10;
+
+		/* With fewer than 10 samples the 10th-90th percentile window
+		 * is empty, which would yield 0/0 NaN means; fall back to the
+		 * untrimmed range. */
+		if (bhi <= blo) { blo = 0; bhi = n_bl; }
+		if (chi <= clo) { clo = 0; chi = n_cur; }
+
+		int bn = bhi - blo, cn = chi - clo;
+		double bs = 0, cs = 0;
+
+		for (int s = blo; s < bhi; s++)
+			bs += (double)all_bl[s] / tsc_ghz;
+		for (int s = clo; s < chi; s++)
+			cs += (double)all_cur[s] / tsc_ghz;
+
+		res.bl_ns = bs / bn;
+		res.cur_ns = cs / cn;
+		res.change = ((res.cur_ns - res.bl_ns) / res.bl_ns) * 100.0;
+
+		struct ks_result ks = ks_test(all_bl + blo, bn,
+					      all_cur + clo, cn);
+		res.ks_d = ks.d;
+		res.ks_p = ks.p;
+	}
+
+	res.regression = (res.change > min_effect);
+	res.improved = (res.change < -min_effect);
+	res.iters = iters;
+	res.n_total = n_bl;
+
+	/* Count outliers using shared IQR threshold */
+	{
+		double q1_bl = (double)all_bl[n_bl / 4] / tsc_ghz;
+		double q3_bl = (double)all_bl[3 * n_bl / 4] / tsc_ghz;
+		double q1_cur = (double)all_cur[n_cur / 4] / tsc_ghz;
+		double q3_cur = (double)all_cur[3 * n_cur / 4] / tsc_ghz;
+		double q1 = q1_bl < q1_cur ? q1_bl : q1_cur;
+		double q3 = q3_bl > q3_cur ? q3_bl : q3_cur;
+		double thresh_ns = q3 + 1.5 * (q3 - q1);
+		uint64_t thresh_t = (uint64_t)(thresh_ns * tsc_ghz);
+
+		res.bl_outliers = 0;
+		res.cur_outliers = 0;
+		for (int s = n_bl - 1; s >= 0 && all_bl[s] > thresh_t; s--)
+			res.bl_outliers++;
+		for (int s = n_cur - 1; s >= 0 && all_cur[s] > thresh_t; s--)
+			res.cur_outliers++;
+	}
+	res.valid = 1;
+
+	/* Save CSV */
+	if (results_dir) {
+		append_csv(results_dir, test->name, cfg->label,
+			   pg->label, "baseline", all_bl, n_bl, tsc_ghz);
+		append_csv(results_dir, test->name, cfg->label,
+			   pg->label, "current", all_cur, n_cur, tsc_ghz);
+	}
+
+out:
+	free(all_bl);
+	free(all_cur);
+	free_shared_buffer(src, test->size, pg->hugepage);
+	free_shared_buffer(dst, test->size, pg->hugepage);
+	return res;
+}
+
+/*
+ * Condensed summary: current-library speedup vs raw CPU, one table per page
+ * size.
+ */
+static void print_speedup_summary(struct cell_result (*all_results)[NUM_DTO_CONFIGS][NUM_PAGE_CONFIGS],
+				  int num_benchmarks)
+{
+	static const char rule[] = "=========================================="
+				   "============================";
+
+	printf("\n%s\n", rule);
+	printf("Speedup vs CPU (current library)\n");
+	printf("%s\n", rule);
+
+	for (int p = 0; p < (int)NUM_PAGE_CONFIGS; p++) {
+		printf("\n%s pages:\n",
+		       page_configs[p].hugepage ? "2MB" : "4KB");
+		printf("%-14s", "Test");
+		for (int c = 1; c < (int)NUM_DTO_CONFIGS; c++)
+			printf("  %10s", dto_configs[c].label);
+		printf("\n");
+		printf("%-14s", "--------------");
+		for (int c = 1; c < (int)NUM_DTO_CONFIGS; c++)
+			printf("  %10s", "----------");
+		printf("\n");
+
+		for (int b = 0; b < num_benchmarks; b++) {
+			if (!test_selected(&benchmarks[b]))
+				continue;
+			if (benchmarks[b].ref_only)
+				continue;
+
+			struct cell_result *cpu_r =
+				&all_results[b][CPU_CONFIG_IDX][p];
+
+			if (!cpu_r->valid)
+				continue;
+
+			printf("%-14s", benchmarks[b].name);
+
+			for (int c = 1; c < (int)NUM_DTO_CONFIGS; c++) {
+				struct cell_result *r = &all_results[b][c][p];
+
+				if (!r->valid)
+					printf("  %10s", "N/A");
+				else
+					printf("  %9.2fx",
+					       cpu_r->cur_ns / r->cur_ns);
+			}
+			printf("\n");
+		}
+	}
+}
+
+int main(void)
+{
+	const char *results_dir = getenv("RESULTS_DIR");
+	const char *cpu_env = getenv("PERF_CPU");
+	const char *effect_env = getenv("PERF_MIN_EFFECT");
+	const char *rounds_env = getenv("PERF_AB_ROUNDS");
+	int cpu = cpu_env ? atoi(cpu_env) : DEFAULT_CPU;
+	/* PERF_SHORT=1: a fast sanity pass — memcpy 4k/64k/1m and memset 64k
+	 * (no fault-injection variants), few iterations, one A/B round —
+	 * sized to finish in well under a minute. Explicit PERF_ITERS/
+	 * PERF_AB_ROUNDS/PERF_MIN_EFFECT still take precedence. Statistical
+	 * verdicts from so few samples are indicative only. */
+	const char *short_env = getenv("PERF_SHORT");
+	short_mode = short_env ? atoi(short_env) : 0;
+	double min_effect = effect_env ? atof(effect_env) : (short_mode ? 5.0 : 2.0);
+	int ab_rounds = rounds_env ? atoi(rounds_env) : (short_mode ? 1 : 3);
+	int errors = 0, failures = 0, skipped = 0;
+
+	{
+		const char *iters_env = getenv("PERF_ITERS");
+
+		if (iters_env)
+			perf_iters = atoi(iters_env);
+		else if (short_mode)
+			perf_iters = 100;
+		if (perf_iters < 1)
+			perf_iters = 1;
+		if (perf_iters > DEFAULT_ITERS)
+			perf_iters = DEFAULT_ITERS;
+	}
+
+	cold_cache = getenv("PERF_COLD_CACHE") ?
+		     atoi(getenv("PERF_COLD_CACHE")) : 1;
+	{
+		const char *op_env = getenv("PERF_OP");
+		if (op_env) {
+			if (strcasecmp(op_env, "memcpy") == 0) filter_op = OP_MEMCPY;
+			else if (strcasecmp(op_env, "memset") == 0) filter_op = OP_MEMSET;
+			else if (strcasecmp(op_env, "memcmp") == 0) filter_op = OP_MEMCMP;
+			else fprintf(stderr, "WARNING: unknown PERF_OP=%s, running all\n", op_env);
+		}
+		const char *size_env = getenv("PERF_SIZE");
+		if (size_env) {
+			char *end;
+			filter_size = strtoul(size_env, &end, 10);
+			if (*end == 'k' || *end == 'K')
+				filter_size *= 1024;
+			else if (*end == 'm' || *end == 'M')
+				filter_size *= 1024 * 1024;
+		}
+	}
+	if (ab_rounds < 1) ab_rounds = 1;
+
+	/* Setup */
+	{
+		struct sched_param sp = { .sched_priority = 1 };
+
+		if (sched_setscheduler(0, SCHED_FIFO, &sp) < 0)
+			fprintf(stderr, "WARNING: could not set SCHED_FIFO\n");
+	}
+	if (pin_to_cpu(cpu) < 0)
+		fprintf(stderr, "WARNING: could not pin to CPU %d\n", cpu);
+	{
+		const char *core_env = getenv("PERF_CORE_FREQ_MHZ");
+		const char *uncore_env = getenv("PERF_UNCORE_FREQ_MHZ");
+		unsigned long core_mhz = core_env ? strtoul(core_env, NULL, 10) : 0;
+		unsigned long uncore_mhz = uncore_env ? strtoul(uncore_env, NULL, 10) : 0;
+
+		if (core_mhz || uncore_mhz) {
+			if (pin_freq(cpu, core_mhz, uncore_mhz) < 0) {
+				fprintf(stderr,
+					"ERROR: PERF_CORE_FREQ_MHZ=%s "
+					"PERF_UNCORE_FREQ_MHZ=%s but could not "
+					"pin. Run as root.\n",
+					core_env ? core_env : "(unset)",
+					uncore_env ? uncore_env : "(unset)");
+			}
+		}
+	}
+
+	tsc_ghz = calibrate_tsc();
+
+	printf("DTO A/B Performance Test (%s cache)\n",
+	       cold_cache ? "cold" : "warm");
+	printf("================================================\n");
+	printf("Pinned CPU:    %d\n", cpu);
+	printf("TSC freq:      %.3f GHz\n", tsc_ghz);
+	print_freq_info(cpu);
+	printf("A/B rounds:    %d (interleaved, randomized order)%s\n",
+	       ab_rounds, short_mode ? " [SHORT]" : "");
+	printf("Iters/round:   %d\n", perf_iters);
+	printf("Min effect:    %.1f%%\n", min_effect);
+	fflush(stdout);
+
+	/* Shared memory for child results */
+	void *shm = mmap(NULL, SHARED_SLOT_SIZE, PROT_READ | PROT_WRITE,
+			 MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+	if (shm == MAP_FAILED) { perror("mmap shm"); return 1; }
+
+	if (results_dir) {
+		char csv_path[4096];
+
+		mkdir(results_dir, 0755);
+		snprintf(csv_path, sizeof(csv_path),
+			 "%s/distributions.csv", results_dir);
+		remove(csv_path);
+	}
+
+	/* Count benchmarks */
+	int num_benchmarks = 0;
+
+	while (benchmarks[num_benchmarks].name)
+		num_benchmarks++;
+
+	/* Store all results: [benchmark][config][pagesize] */
+	struct cell_result (*all_results)[NUM_DTO_CONFIGS][NUM_PAGE_CONFIGS];
+
+	all_results = calloc(num_benchmarks,
+			     sizeof(*all_results));
+	if (!all_results) {
+		perror("calloc results");
+		return 1;
+	}
+
+	/*
+	 * Run all benchmarks and collect results.
+	 * Then print two detail tables (one per page size) and a summary.
+	 */
+	for (int b = 0; b < num_benchmarks; b++) {
+		struct perf_test *test = &benchmarks[b];
+
+		if (!test_selected(test))
+			continue;
+
+		for (int c = 0; c < (int)NUM_DTO_CONFIGS; c++) {
+			for (int p = 0; p < (int)NUM_PAGE_CONFIGS; p++) {
+				all_results[b][c][p] = run_cell(
+					test, &dto_configs[c], &page_configs[p],
+					shm, ab_rounds, min_effect,
+					results_dir);
+
+				if (all_results[b][c][p].skipped)
+					skipped++;
+				else if (!all_results[b][c][p].valid)
+					errors++;
+				/* The cpu config runs libc against itself, so
+				 * its "change" is pure noise — never a
+				 * regression verdict. */
+				else if (all_results[b][c][p].regression &&
+					 !test->ref_only &&
+					 c != CPU_CONFIG_IDX)
+					failures++;
+
+				printf("    [done] %-14s %-10s %-4s\n",
+				       test->name, dto_configs[c].label,
+				       page_configs[p].label);
+				fflush(stdout);
+			}
+		}
+	}
+
+	munmap(shm, SHARED_SLOT_SIZE);
+
+	/*
+	 * ---- Detail tables: one per page size ----
+	 *
+	 * Each table has a row per transaction size, with sub-rows
+	 * for each DTO config (cpu, stdc, dsa, dsa_auto).
+	 */
+	for (int p = 0; p < (int)NUM_PAGE_CONFIGS; p++) {
+		printf("\n  ==============================="
+		       "=======================================\n");
+		printf("  A/B Results — %s pages\n",
+		       page_configs[p].hugepage ? "2MB" : "4KB");
+		printf("  ==============================="
+		       "=======================================\n");
+		printf("  %-13s %-9s %-9s   %-9s %-8s %-5s   %-7s   %s\n",
+		       "Test", "Config",
+		       "Base mean", "Cur mean",
+		       "Change", "KS D", "Result", "Outliers");
+		printf("  %-13s %-9s %-9s   %-9s %-8s %-5s   %-7s   %s\n",
+		       "-------------", "---------",
+		       "---------", "---------",
+		       "--------", "-----", "-------",
+		       "--------");
+		for (int b = 0; b < num_benchmarks; b++) {
+			if (!test_selected(&benchmarks[b]))
+				continue;
+			for (int c = 0; c < (int)NUM_DTO_CONFIGS; c++) {
+				struct cell_result *r =
+					&all_results[b][c][p];
+
+				if (c == 0)
+					printf("  %-13s", benchmarks[b].name);
+				else
+					printf("  %-13s", "");
+
+				printf(" %-9s", dto_configs[c].label);
+
+				if (r->skipped) {
+					printf(" %6s ns   %6s ns %8s %-5s   SKIP\n",
+					       "", "", "", "");
+				} else if (!r->valid) {
+					printf(" %6s ns   %6s ns %8s %-5s   ERROR\n",
+					       "", "", "", "");
+				} else {
+					const char *result;
+
+					if (benchmarks[b].ref_only ||
+					    c == CPU_CONFIG_IDX)
+						result = "REF";
+					else if (r->regression)
+						result = "FAIL ***";
+					else if (r->improved)
+						result = "IMPROVED";
+					else
+						result = "PASS";
+
+					printf(" %6.0f ns   %6.0f ns "
+					       "%+7.1f%% %-5.3f   %-7s   "
+					       "bl=%d cur=%d\n",
+					       r->bl_ns, r->cur_ns,
+					       r->change, r->ks_d,
+					       result,
+					       r->bl_outliers,
+					       r->cur_outliers);
+				}
+			}
+		}
+	}
+
+	/* ---- Summary: current library speedup vs CPU ---- */
+	print_speedup_summary(all_results, num_benchmarks);
+
+	/* Final summary */
+	if (failures > 0)
+		printf("  %d regression(s) detected (> +%.1f%%)\n",
+		       failures, min_effect);
+	else
+		printf("  No regressions (threshold: +%.1f%%)\n", min_effect);
+	if (errors > 0)
+		printf("  %d error(s)\n", errors);
+	if (skipped > 0)
+		printf("  %d cell(s) skipped: 2MB pages unavailable "
+		       "(reserve some via /proc/sys/vm/nr_hugepages)\n",
+		       skipped);
+
+	free(all_results);
+	return (failures > 0 || errors > 0) ? 1 : 0;
+}


### PR DESCRIPTION
**Stack 3/3** — stacked on `cmake-numa-accel` (#31).

Adds a CTest-driven test suite:

- a **functional** correctness test that runs without DSA hardware
- an A/B **performance** regression test comparing the current `dto.c` against a baseline object built from the baseline branch

See `TESTING.md` for usage.

